### PR TITLE
Disable correlations with `merged-chats` flag

### DIFF
--- a/Beeper/BarcelonaMautrixIPC/MXFeatureFlags.swift
+++ b/Beeper/BarcelonaMautrixIPC/MXFeatureFlags.swift
@@ -18,7 +18,4 @@ public class MXFeatureFlags: FlagProvider {
     
     @FeatureFlag("merged-chats", defaultValue: false)
     public var mergedChats: Bool
-
-    @FeatureFlag("correlated-chats", defaultValue: false)
-    public var correlatedChats: Bool
 }

--- a/Beeper/BarcelonaMautrixIPC/MXFeatureFlags.swift
+++ b/Beeper/BarcelonaMautrixIPC/MXFeatureFlags.swift
@@ -18,4 +18,7 @@ public class MXFeatureFlags: FlagProvider {
     
     @FeatureFlag("merged-chats", defaultValue: false)
     public var mergedChats: Bool
+
+    @FeatureFlag("correlated-chats", defaultValue: false)
+    public var correlatedChats: Bool
 }

--- a/Beeper/barcelona-mautrix/BarcelonaMautrix.swift
+++ b/Beeper/barcelona-mautrix/BarcelonaMautrix.swift
@@ -100,6 +100,9 @@ class BarcelonaMautrix {
             LoggingDrivers = CBFeatureFlags.runningFromXcode ? [OSLogDriver.shared] : [OSLogDriver.shared, ConsoleDriver.shared]
             BLMetricStore.shared.set(true, forKey: .shouldDebugPayloads)
         }
+
+        // Update barcelona to respect whatever flags were passed into mautrix
+        CBFeatureFlags.correlateChats = MXFeatureFlags.shared.correlatedChats
     }
     
     // starts the bridge state interval

--- a/Beeper/barcelona-mautrix/BarcelonaMautrix.swift
+++ b/Beeper/barcelona-mautrix/BarcelonaMautrix.swift
@@ -101,8 +101,8 @@ class BarcelonaMautrix {
             BLMetricStore.shared.set(true, forKey: .shouldDebugPayloads)
         }
 
-        // Update barcelona to respect whatever flags were passed into mautrix
-        CBFeatureFlags.correlateChats = MXFeatureFlags.shared.correlatedChats
+        // Only correlate chats if mautrix wants us to merge them
+        CBFeatureFlags.correlateChats = MXFeatureFlags.shared.mergedChats
     }
     
     // starts the bridge state interval

--- a/Core/Barcelona/CoreBarcelona/CBFeatureFlags.swift
+++ b/Core/Barcelona/CoreBarcelona/CBFeatureFlags.swift
@@ -72,6 +72,7 @@ public class _CBFeatureFlags: FlagProvider {
     
     @_spi(featureFlags) public var overrideWithholdPartialFailures: Bool?
     @_spi(featureFlags) public var overrideWithholdDupes: Bool?
+    public var correlateChats: Bool = true
     
     @FeatureFlag("withhold-partial-failures", defaultValue: true)
     private var _withholdPartialFailures: Bool

--- a/Core/Barcelona/CoreBarcelona/CBSenderCorrelationController.swift
+++ b/Core/Barcelona/CoreBarcelona/CBSenderCorrelationController.swift
@@ -592,7 +592,11 @@ extension Message: CBSenderTargetable {
 extension IMChat {
     /// Returns other chats with the same sender correlation ID
     public var siblings: [IMChat] {
-        if isGroup {
+        // This is a band-aid for now. Since this doesn't try to merge
+        // SMS<->iMessage conversations, this flag (`correlateChats`)
+        // controls chat merging along with correlating.
+        // TODO: Actually separate them out and fix correlation lol
+        if isGroup || !CBFeatureFlags.correlateChats {
             return [self]
         } else {
             var siblings = recipient?.senderDestination.map { destination in


### PR DESCRIPTION
With this PR, passing in `--enabled-merged-chats` to barcelona-mautrix will maintain current behavior, but passing in `--disable-merged-chats` or not passing in any flag will disable both chat merging and chat correlation (i.e. merging based on correlation ids)