### PR TITLE
Support unix sockets (BE-6772)

### DIFF
--- a/Beeper/BarcelonaMautrixIPC/Runtime/BLStandardIO.swift
+++ b/Beeper/BarcelonaMautrixIPC/Runtime/BLStandardIO.swift
@@ -72,7 +72,7 @@ extension FileHandle: MautrixIPCInputChannel {
 }
 
 extension FileHandle: MautrixIPCOutputChannel {
-    
+    // FileHandle implements func write(_ data: Data) already.
 }
 
 private extension Data {

--- a/Beeper/BarcelonaMautrixIPC/Runtime/BLStandardIO.swift
+++ b/Beeper/BarcelonaMautrixIPC/Runtime/BLStandardIO.swift
@@ -65,6 +65,16 @@ public extension FileHandle {
     }
 }
 
+extension FileHandle: MautrixIPCInputChannel {
+    public func listen(_ cb: @escaping (Data) -> ()) {
+        self.handleDataAsynchronously(cb)
+    }
+}
+
+extension FileHandle: MautrixIPCOutputChannel {
+    
+}
+
 private extension Data {
     func split(separator: Data) -> [Data] {
         var chunks: [Data] = []

--- a/Beeper/BarcelonaMautrixIPC/Runtime/UnixSocketMautrixIPCChannel.swift
+++ b/Beeper/BarcelonaMautrixIPC/Runtime/UnixSocketMautrixIPCChannel.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Socket
+import Swog
+
+fileprivate let log = Logger(category: "UnixSocketMautrixIPCChannel")
+
+public class UnixSocketMautrixIPCChannel: MautrixIPCInputChannel, MautrixIPCOutputChannel {
+    private let socket: Socket
+    private var readThread: Thread? = nil
+    private var readRunLoop: CFRunLoop? = nil
+    private var readCallback: ((Data) -> ())? = nil
+    
+    public init(_ socketPath: String) {
+        do {
+            try socket = Socket.create(family:.unix)
+            try socket.connect(to: socketPath)
+            log.info("Connected to unix socket \(socketPath)")
+        } catch let error {
+            fatalError("Failed to connect unix socket \(error)")
+        }
+    }
+    
+    private func setupReadThread() {
+        readThread = Thread {
+            self.readRunLoop = CFRunLoopGetCurrent()
+            
+            RunLoop.current.schedule {
+                do {
+                    var shouldKeepRunning = true
+                    
+                    repeat {
+                        log.info("Waiting for data")
+                        var readData = Data(capacity: 4096)
+                        let bytesRead = try self.socket.read(into: &readData)
+                        log.info("Read \(bytesRead) bytes from the unix socket")
+                        
+                        if bytesRead > 0 {
+                            if let readCallback = self.readCallback {
+                                readCallback(readData)
+                            }
+                        }
+                        
+                        if bytesRead == 0 {
+                            shouldKeepRunning = false
+                            break
+                        }
+                    } while shouldKeepRunning
+                } catch let error {
+                    log.error("Failed to read payload from unix socket: \(String(describing: error))")
+                }
+            }
+            
+            RunLoop.current.run()
+        }
+    }
+    
+    func performOnThread(_ callback: @escaping () -> ()) {
+        guard let runLoop = readRunLoop else {
+            // Thread not yet started, just call it immediately
+            callback()
+            return
+        }
+        CFRunLoopPerformBlock(runLoop, CFRunLoopMode.commonModes.rawValue, callback)
+        CFRunLoopWakeUp(runLoop)
+    }
+    
+    public func listen(_ cb: @escaping (Data) -> ()) {
+        self.readCallback = cb
+        if readThread == nil {
+            setupReadThread()
+        }
+        readThread!.start()
+    }
+    
+    public func write(_ data: Data) {
+        do {
+            log.info("Writing \(data.count) bytes to the unix socket")
+            try socket.write(from: data)
+        } catch let error {
+            log.error("Failed to write payload to unix socket: \(String(describing: error))")
+        }
+    }
+}

--- a/Beeper/BarcelonaMautrixIPC/Runtime/UnixSocketMautrixIPCChannel_Tests.swift
+++ b/Beeper/BarcelonaMautrixIPC/Runtime/UnixSocketMautrixIPCChannel_Tests.swift
@@ -1,0 +1,118 @@
+//
+//  UnixSocketMautrixIPCChannel_Tests.swift
+//  BarcelonaMautrixIPCTests
+//
+//  Created by Joonas Myhrberg on 29.1.2023.
+//
+
+import NIO
+import NIOFoundationCompat
+import XCTest
+
+@testable import BarcelonaMautrixIPC
+
+final class UnixSocketMautrixIPCChannel_Tests: XCTestCase {
+
+    /// Default buffer is 2048, write more than that to test multiple calls to read/write.
+    private let numberOfTestBytes = 3000
+
+    func testRead() throws {
+        let testSocketPath = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString).path()
+
+        let randomBytes = (0..<numberOfTestBytes).map { _ in UInt8.random(in: 0...UInt8.max) }
+        let wantData = Data(randomBytes)
+
+        let expectation = expectation(description: "client received bytes")
+
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let server = ServerBootstrap(group: group)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .childChannelInitializer { channel in
+                channel.pipeline.addHandler(TestWriter(data: wantData))
+            }
+        let testServerChannel = try server.bind(unixDomainSocketPath: testSocketPath).wait()
+
+        let ipcChannel = UnixSocketMautrixIPCChannel(testSocketPath)
+
+        var receivedData = Data()
+        ipcChannel.listen { data in
+            receivedData.append(data)
+            if receivedData.count == wantData.count {
+                expectation.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: 1)
+
+        XCTAssertEqual(receivedData, wantData)
+
+        try testServerChannel.close().wait()
+        try testServerChannel.closeFuture.wait()
+    }
+
+    func testWrite() throws {
+        let testSocketPath = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString).path()
+
+        let randomBytes = (0..<numberOfTestBytes).map { _ in UInt8.random(in: 0...UInt8.max) }
+        let randomData = Data(randomBytes)
+
+        let expectation = expectation(description: "server received bytes")
+
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let server = ServerBootstrap(group: group)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .childChannelInitializer { channel in
+                channel.pipeline.addHandler(ReceiveTester(wantData: randomData, expectation: expectation))
+            }
+        let testServerChannel = try server.bind(unixDomainSocketPath: testSocketPath).wait()
+
+        let ipcChannel = UnixSocketMautrixIPCChannel(testSocketPath)
+
+        ipcChannel.write(randomData)
+
+        waitForExpectations(timeout: 1)
+
+        try testServerChannel.close().wait()
+        try testServerChannel.closeFuture.wait()
+    }
+}
+
+private class TestWriter: ChannelInboundHandler {
+    typealias InboundIn = ByteBuffer
+
+    private let data: Data
+
+    init(data: Data) {
+        self.data = data
+    }
+
+    func channelActive(context: ChannelHandlerContext) {
+        let bytes = context.channel.allocator.buffer(data: data)
+        context.writeAndFlush(NIOAny(bytes), promise: nil)
+    }
+}
+
+private class ReceiveTester: ChannelInboundHandler {
+    typealias InboundIn = ByteBuffer
+
+    private let wantData: Data
+    private let expectation: XCTestExpectation
+
+    private var receivedBytes = [UInt8]()
+    private var received = Data()
+
+    init(wantData: Data, expectation: XCTestExpectation) {
+        self.wantData = wantData
+        self.expectation = expectation
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        let bytes = unwrapInboundIn(data)
+        received.append(contentsOf: bytes.readableBytesView)
+
+        if received.count == wantData.count {
+            XCTAssertEqual(received, wantData)
+            expectation.fulfill()
+        }
+    }
+}

--- a/Beeper/barcelona-mautrix/BarcelonaMautrix.swift
+++ b/Beeper/barcelona-mautrix/BarcelonaMautrix.swift
@@ -53,12 +53,13 @@ class BarcelonaMautrix {
         }
     }
     
-    static func getUnixSocketPath() -> Optional<String> {
-        let index = ProcessInfo.processInfo.arguments.firstIndex(of: "--unix-socket")
-        if let index {
-            return ProcessInfo.processInfo.arguments[index + 1]
+    static func getUnixSocketPath() -> String? {
+        guard let index = ProcessInfo.processInfo.arguments.firstIndex(of: "--unix-socket"),
+            ProcessInfo.processInfo.arguments.count > index + 1
+        else {
+            return nil
         }
-        return nil
+        return ProcessInfo.processInfo.arguments[index + 1]
     }
     
     static func main() {

--- a/XCSpec/barcelona.yaml
+++ b/XCSpec/barcelona.yaml
@@ -17,6 +17,7 @@ targets:
       - package: FeatureFlags
       - package: SwiftCLI
       - package: Sentry
+      - package: Socket
       - package: Paris
         product: CommunicationsFilter
       - package: Paris

--- a/XCSpec/barcelona.yaml
+++ b/XCSpec/barcelona.yaml
@@ -17,7 +17,10 @@ targets:
       - package: FeatureFlags
       - package: SwiftCLI
       - package: Sentry
-      - package: Socket
+      - package: SwiftNIO
+        product: NIO
+      - package: SwiftNIO
+        product: NIOFoundationCompat
       - package: Paris
         product: CommunicationsFilter
       - package: Paris
@@ -56,7 +59,7 @@ targets:
   grapple:
     group: Tools
     type: tool
-    platform: [macOS,iOS]
+    platform: [macOS, iOS]
     platformSuffix: -${platform}
     productNameFromSettings: true
     sources:

--- a/XCSpec/beeper.yaml
+++ b/XCSpec/beeper.yaml
@@ -5,7 +5,9 @@ targets:
     templates:
       - BLFramework
     sources:
-      - ../Beeper/BarcelonaMautrixIPC
+      - path: ../Beeper/BarcelonaMautrixIPC
+        excludes:
+          - "**/*_Tests.swift"
     scheme:
       testTargets:
         - barcelona-mautrix-tests
@@ -21,7 +23,7 @@ targets:
   barcelona-mautrix:
     group: Beeper
     type: tool
-    platform: [macOS,iOS]
+    platform: [macOS, iOS]
     platformSuffix: -${platform}
     productNameFromSettings: true
     sources:
@@ -71,4 +73,17 @@ targets:
       - BLTestHost
     templateAttributes:
       entitlements: Beeper/BarcelonaTest/entitlements.plist
-
+  BarcelonaMautrixIPCTests:
+    type: bundle.unit-test
+    platform: macOS
+    settings:
+      base:
+        MACOSX_DEPLOYMENT_TARGET: "13.0"
+    dependencies:
+      - target: BarcelonaMautrixIPC
+        embed: true
+        link: true
+    sources:
+      - path: ../Beeper/BarcelonaMautrixIPC
+        includes:
+          - "**/*_Tests.swift"

--- a/XCSpec/spm.yaml
+++ b/XCSpec/spm.yaml
@@ -62,3 +62,6 @@ packages:
   Paris:
     url: https://github.com/EricRabil/Paris
     revision: "be1e5335cdea99f86f4ebd25200ed37eea7dd831"
+  Socket:
+    url: https://github.com/Kitura/BlueSocket
+    from: 2.0.2

--- a/XCSpec/spm.yaml
+++ b/XCSpec/spm.yaml
@@ -62,6 +62,6 @@ packages:
   Paris:
     url: https://github.com/EricRabil/Paris
     revision: "be1e5335cdea99f86f4ebd25200ed37eea7dd831"
-  Socket:
-    url: https://github.com/Kitura/BlueSocket
-    from: 2.0.2
+  SwiftNIO:
+    url: https://github.com/apple/swift-nio
+    from: 2.0.0


### PR DESCRIPTION
It works! It kind of sucks though.

* Created `MautrixIPCInputChannel` and `MautrixIPCOutputChannel` protocols that are simple and all the MautrixIPCChannel needs, adapted our FileHandle extensions to implement those (though it feels weird banging so much stuff onto FileHandle).
* Flips writes in MautrixIPCChannel to use a pipeline to serialize instead of stealing the writer thread from the underlying FileHandle.
* Wrote a janky UnixSocketMautrixIPCChannel class to implement MautrixIPCInputChannel and MautrixIPCOutputChannel for unix sockets using https://github.com/Kitura/BlueSocket, though I'm not convinced my error handling is good.
* Janky command line parsing to grab the unix socket path.

Questions for @tulir :
* I noticed that if I control-C'd mautrix-imessage I couldn't run it again without deleting the unix socket path I used (couldn't bind to an already bound socket error). Who should clean up the unix socket on exit? Should we use a randomized path so that we avoid issues with dangling sockets?
* Where should we pipe stdout and stdin of barcelona mautrix to? Might be nice to have mautrix-imessage pipe them to a file somewhere so it's easy for promtail to pick up?