### PR TITLE
Send regardless of IDS availability (#BE-7149)

### DIFF
--- a/Core/Barcelona/CoreBarcelona/Paris/CBChat.swift
+++ b/Core/Barcelona/CoreBarcelona/Paris/CBChat.swift
@@ -221,10 +221,6 @@ public extension CBChat {
     var senderLastAddressedSIMID: String? {
         mostRecentChat?.lastAddressedSIMID
     }
-    
-    var serviceForSending: IMService {
-        IMChats.contains { $0.account.service == .iMessage() } ? .iMessage() : .sms()
-    }
 
     func validRecipients(on service: IMServiceImpl = .iMessage()) -> [IMHandle] {
         guard style == .instantMessage else {

--- a/Core/Barcelona/IDS.swift
+++ b/Core/Barcelona/IDS.swift
@@ -159,8 +159,11 @@ public func BLResolveIDStatusForIDs(_ ids: [String], onService service: IMServic
         
         log.info("Requesting ID status from server for destinations \(destinations.joined(separator: ","), privacy: .auto) on service \(service.idsIdentifier ?? "nil", privacy: .public)")
         
-        IDSIDQueryController.sharedInstance()!.forceRefreshIDStatus(forDestinations: destinations, service: service.idsIdentifier!, listenerID: IDSListenerID, queue: HandleQueue) {
-            callback($0.mapValues { IDSState(rawValue: $0.intValue) })
+        IDSIDQueryController.sharedInstance()!.forceRefreshIDStatus(forDestinations: destinations, service: service.idsIdentifier!, listenerID: IDSListenerID, queue: HandleQueue) { states in
+            let mappedStates = states.mapValues { IDSState(rawValue: $0.intValue) }
+            
+            log.debug("forceRefreshIDStatus completed with result: \(mappedStates)")
+            callback(mappedStates)
         }
     }
     

--- a/Core/Barcelona/IMCoreHelpers/RegressionTesting.swift
+++ b/Core/Barcelona/IMCoreHelpers/RegressionTesting.swift
@@ -94,12 +94,14 @@ public extension BLRegressionTesting {
             }
         },
         "iChatForSending": {
-            let chat = CBChatRegistry.shared.chats[.guid(ProcessInfo.processInfo.environment["CHAT_GUID"]!)]!
-            print(chat.chatForSending(on: .iMessage).debugDescription)
+            let guid = ProcessInfo.processInfo.environment["CHAT_GUID"]!
+            let chat = CBChatRegistry.shared.chats[.guid(guid)]!
+            print(chat.chatForSending(with: guid).debugDescription)
         },
         "sChatForSending": {
-            let chat = CBChatRegistry.shared.chats[.guid(ProcessInfo.processInfo.environment["CHAT_GUID"]!)]!
-            print(chat.chatForSending(on: .SMS).debugDescription)
+            let guid = ProcessInfo.processInfo.environment["CHAT_GUID"]!
+            let chat = CBChatRegistry.shared.chats[.guid(guid)]!
+            print(chat.chatForSending(with: guid).debugDescription)
         }
     ]
     

--- a/Core/Barcelona/Wrappers/Core/Messaging/MessageSending.swift
+++ b/Core/Barcelona/Wrappers/Core/Messaging/MessageSending.swift
@@ -87,7 +87,7 @@ public extension Chat {
     func sendReturningRaw(message createMessage: CreateMessage, from: String? = nil) throws -> IMMessage {
         if CBFeatureFlags.useSendingV2, let cbChat = cbChat {
             CLInfo("MessageSending", "Using CBChat for sending per feature flags")
-            return try cbChat.send(message: createMessage, service: CBServiceName(style: service ?? .iMessage))
+            return try cbChat.send(message: createMessage, guid: imChat.guid)
         }
         
         imChat.refreshServiceForSendingIfNeeded()
@@ -108,43 +108,11 @@ public extension Chat {
         return message
     }
     
-    func send(message options: CreatePluginMessage) throws -> Message {
-        if CBFeatureFlags.useSendingV2, let cbChat = cbChat {
-            CLInfo("MessageSending", "Using CBChat for sending per feature flags")
-            let message = try options.imMessage(inChat: id)
-            cbChat.send(message: message)
-            return Message(ingesting: message, context: .init(chatID: id))!
-        }
-        
-        imChat.refreshServiceForSendingIfNeeded()
-        
-        let message = try options.imMessage(inChat: self.id)
-        
-        Chat.delegate?.chat(self, willSendMessages: [message], fromCreatePluginMessage: options)
-        
-        Thread.main.sync {
-            markAsRead()
-            imChat.send(message)
-        }
-        
-        return Message(messageItem: message._imMessageItem, chatID: imChat.id)
-    }
-    
     func send(message createMessage: CreateMessage, from: String? = nil) throws -> Message {
         return Message(messageItem: try sendReturningRaw(message: createMessage, from: from)._imMessageItem, chatID: imChat.id)
     }
     
     func tapback(_ creation: TapbackCreation, metadata: Message.Metadata? = nil) throws -> Message {
-        func chatForSending() -> IMChat {
-            if CBFeatureFlags.useSendingV2, let cbChat = cbChat {
-                CLInfo("MessageSending", "Using CBChat for sending per feature flags")
-                return cbChat.chatForSending(on: .iMessage) ?? self.imChat
-            } else {
-                return self.imChat
-            }
-        }
-        let imChat = chatForSending()
-        
         markAsRead()
         let message = try imChat.tapback(guid: creation.message, itemGUID: creation.item, type: creation.type, overridingItemType: nil, metadata: metadata)
         

--- a/Core/Barcelona/Wrappers/Core/Messaging/MessageSending.swift
+++ b/Core/Barcelona/Wrappers/Core/Messaging/MessageSending.swift
@@ -87,7 +87,7 @@ public extension Chat {
     func sendReturningRaw(message createMessage: CreateMessage, from: String? = nil) throws -> IMMessage {
         if CBFeatureFlags.useSendingV2, let cbChat = cbChat {
             CLInfo("MessageSending", "Using CBChat for sending per feature flags")
-            return try cbChat.send(message: createMessage)
+            return try cbChat.send(message: createMessage, service: CBServiceName(style: service ?? .iMessage))
         }
         
         imChat.refreshServiceForSendingIfNeeded()


### PR DESCRIPTION
This sends messages without checking for the recipient's current IDS availability. This will hopefully stop spurious IDS failures from causing messages to fail to send, and also prevent downgrading to different chats when one currently isn't available (which we also don't want, so this is good)

There is an issue (not a bug, just a design issue) here where the `CBChat` object contains an `IMChats` array which references all the correlated chats of the same service (iMsg vs SMS) for the contact this chat refers to. And `CBChat`s are the ones who handle sending, so we need to use some data (currently we're using the guid of the `IMChat`) to find the `IMChat` to do the actual sending, and this just makes things more difficult than they need to be.

Ideally we wouldn't be using `CBChat`s now since they are a relic of correlating chats, and we would just use `Chat`s instead (since each `Chat` is 1:1 with an `IMChat`, which makes a lot of things easier for us), but that'll take a lot of work to untangle it, which time I assume we don't want to put in right now.

This also removes some dead code and adds more logs