### PR TITLE
Fix crash in ERTimeSortedParticipantsManager

### DIFF
--- a/Core/Barcelona/Extensions/Tapbacks/IMChat+Acknowledgment.swift
+++ b/Core/Barcelona/Extensions/Tapbacks/IMChat+Acknowledgment.swift
@@ -41,11 +41,7 @@ public extension IMChat {
 
         let rawType = Int64(type)
 
-        if #available(macOS 13, iOS 16.0, *) {
-            return try venturaTapback(associatedMessageType: rawType, messageSummaryInfo: summaryInfo, messagePartChatItem: subpart)
-        } else {
-            return try preVenturaTapback(type: rawType, overridingItemType: overridingItemType, subpart: subpart, summaryInfo: summaryInfo)
-        }
+        return try venturaTapback(associatedMessageType: rawType, messageSummaryInfo: summaryInfo, messagePartChatItem: subpart)
     }
 
     @available(macOS 13.0, *)
@@ -76,44 +72,5 @@ public extension IMChat {
         send(message)
 
         return message
-    }
-
-    @available(macOS, obsoleted: 13.0, message: "Use venturaTapback instead")
-    @available(iOS, obsoleted: 16.0, message: "Use venturaTapback instead")
-    func preVenturaTapback(
-        type: Int64,
-        overridingItemType: UInt8?,
-        subpart: IMMessagePartChatItem,
-        summaryInfo: [AnyHashable: Any],
-        metadata: Message.Metadata? = nil
-    ) throws -> IMMessage {
-        guard let compatibilityString = CBGeneratePreviewStringForAcknowledgmentType(type, summaryInfo: summaryInfo),
-              let superFormat = IMCreateSuperFormatStringFromPlainTextString(compatibilityString) else {
-            throw BarcelonaError(code: 500, message: "Internal server error")
-        }
-
-        let adjustedSummaryInfo = IMChat.__im_adjustMessageSummaryInfo(forSending: summaryInfo)
-        let guid = subpart.guid
-        let range = subpart.messagePartRange
-
-        var toSendMessage: IMMessage?
-
-        if #available(iOS 14, macOS 10.16, watchOS 7, *) {
-            toSendMessage = IMMessage.instantMessage(withAssociatedMessageContent: superFormat, flags: 0, associatedMessageGUID: guid, associatedMessageType: type, associatedMessageRange: range, messageSummaryInfo: adjustedSummaryInfo, threadIdentifier: nil)
-        } else {
-            toSendMessage = IMMessage.instantMessage(withAssociatedMessageContent: superFormat, flags: 0, associatedMessageGUID: guid, associatedMessageType: type, associatedMessageRange: range, messageSummaryInfo: adjustedSummaryInfo)
-        }
-
-        guard let toSendMessage else {
-            throw BarcelonaError(code: 500, message: "Couldn't create tapback message")
-        }
-
-        if let metadata {
-            toSendMessage.metadata = metadata
-        }
-
-        send(toSendMessage)
-
-        return toSendMessage
     }
 }

--- a/Core/Barcelona/IMCoreHelpers/ERTimeSortedParticipantsManager.swift
+++ b/Core/Barcelona/IMCoreHelpers/ERTimeSortedParticipantsManager.swift
@@ -6,10 +6,9 @@
 //  Copyright © 2020 Eric Rabil. All rights reserved.
 //
 
+import BarcelonaDB
 import Foundation
 import IMCore
-import os.log
-import BarcelonaDB
 import IMSharedUtilities
 import Logging
 
@@ -18,16 +17,16 @@ private let log = Logger(label: "ParticipantsManager")
 public struct ParticipantSortRule: Equatable, Hashable {
     var handleID: String
     var lastSentMessageTime: Double
-    
+
     public func hash(into hasher: inout Hasher) {
         handleID.hash(into: &hasher)
     }
-    
+
     public var hashValue: Int {
         handleID.hashValue
     }
-    
-    public static func ==(lhs: ParticipantSortRule, rhs: ParticipantSortRule) -> Bool {
+
+    public static func == (lhs: ParticipantSortRule, rhs: ParticipantSortRule) -> Bool {
         lhs.handleID == rhs.handleID
     }
 }
@@ -42,13 +41,13 @@ extension ERTimeSortedParticipantsManagerIngestible {
         guard let handleID = senderID else {
             return nil
         }
-        
+
         return ParticipantSortRule(handleID: handleID, lastSentMessageTime: effectiveTime)
     }
 }
 
-fileprivate extension ERTimeSortedParticipantsManagerIngestible {
-    var bestHandleIDForMe: String? {
+extension ERTimeSortedParticipantsManagerIngestible {
+    fileprivate var bestHandleIDForMe: String? {
         Registry.sharedInstance.uniqueMeHandleIDs.first
     }
 }
@@ -57,7 +56,7 @@ extension IMItem: ERTimeSortedParticipantsManagerIngestible {
     public var senderID: String? {
         resolveSenderID(inService: serviceStyle) ?? (isFromMe ? bestHandleIDForMe : nil)
     }
-    
+
     public var effectiveTime: Double {
         (self.time?.timeIntervalSince1970 ?? 0) * 1000
     }
@@ -67,7 +66,7 @@ extension IMMessage: ERTimeSortedParticipantsManagerIngestible {
     public var senderID: String? {
         resolveSenderID(inService: _imMessageItem?.serviceStyle) ?? (isFromMe ? bestHandleIDForMe : nil)
     }
-    
+
     public var effectiveTime: Double {
         (self.time?.timeIntervalSince1970 ?? 0) * 1000
     }
@@ -82,7 +81,7 @@ extension IMTranscriptChatItem {
             return transcriptDate ?? _item()?.time
         }
     }
-    
+
     public var effectiveTime: Double {
         (reliableDate?.timeIntervalSince1970 ?? 0) * 1000
     }
@@ -92,22 +91,22 @@ extension Message: ERTimeSortedParticipantsManagerIngestible {
     public var senderID: String? {
         self.sender ?? (fromMe ? bestHandleIDForMe : nil)
     }
-    
+
     public var effectiveTime: Double {
         self.time
     }
 }
 
-private extension Array {
-    func appending(_ element: Element) -> [Element] {
+extension Array {
+    fileprivate func appending(_ element: Element) -> [Element] {
         var array = self
         array.append(element)
         return array
     }
 }
 
-private extension Notification {
-    var chat: IMChat? {
+extension Notification {
+    fileprivate var chat: IMChat? {
         object as? IMChat ?? userInfo?["user"] as? IMChat
     }
 }
@@ -120,109 +119,137 @@ extension NotificationCenter {
 
 public class ERTimeSortedParticipantsManager {
     public static let sharedInstance = ERTimeSortedParticipantsManager()
-    
+
     private init() {
         NotificationCenter.default.addObserver(forName: ERChatMessagesReceivedNotification) { notification in
             if let ingestible = notification.object as? [ERTimeSortedParticipantsManagerIngestible] {
                 self.ingest(items: ingestible, inChat: notification.userInfo!["chat"] as! String)
             }
         }
-        
+
         NotificationCenter.default.addObserver(forName: ERChatMessageReceivedNotification) { notification in
             if let ingestible = notification.object as? ERTimeSortedParticipantsManagerIngestible {
                 self.ingest(item: ingestible, inChat: notification.userInfo!["chat"] as! String)
             }
         }
-        
-        NotificationCenter.default.addObserver(forName: .IMChatRegistryDidRegisterChat, using: ingest(bootstrapNotification:))
-        
-        NotificationCenter.default.addObserver(forName: .IMChatRegistryDidUnregisterChat, using: ingest(bootstrapNotification:))
-        
-        NotificationCenter.default.addObserver(forName: .IMChatParticipantsDidChange, using: ingest(bootstrapNotification:))
+
+        NotificationCenter.default.addObserver(
+            forName: .IMChatRegistryDidRegisterChat,
+            using: ingest(bootstrapNotification:)
+        )
+
+        NotificationCenter.default.addObserver(
+            forName: .IMChatRegistryDidUnregisterChat,
+            using: ingest(bootstrapNotification:)
+        )
+
+        NotificationCenter.default.addObserver(
+            forName: .IMChatParticipantsDidChange,
+            using: ingest(bootstrapNotification:)
+        )
     }
-    
+
     private func ingest(bootstrapNotification notification: Notification) {
         if let chat = notification.chat {
-            log.info("Recomputing sorted participants with chat ID \(chat.id) per notification \(notification.name.rawValue)")
-            self.bootstrap(chat: chat).then {
-                log.info("Finished recomputing sorted participants with chat ID \(chat.id) per notification \(notification.name.rawValue)")
+            do {
+                log.info(
+                    "Recomputing sorted participants with chat ID \(chat.id) per notification \(notification.name.rawValue)"
+                )
+                try bootstrap(chat: chat)
+                log.info(
+                    "Finished recomputing sorted participants with chat ID \(chat.id) per notification \(notification.name.rawValue)"
+                )
+            } catch {
+                log.error("Error ")
             }
         }
     }
-    
+
     var chatToParticipantSortRules: [String: [ParticipantSortRule]] = [:]
-    
+
     public func sortedParticipants(forChat chat: String) -> [String] {
         chatToParticipantSortRules[chat]?.map(\.handleID) ?? []
     }
-    
+
     public func ingest(item: IMItem, inChat chat: String) {
         self.ingest(item: item as ERTimeSortedParticipantsManagerIngestible, inChat: chat)
     }
-    
+
     public func ingest(item: IMMessageItem, inChat chat: String) {
         self.ingest(item: item as ERTimeSortedParticipantsManagerIngestible, inChat: chat)
     }
-    
+
     public func ingest(item: IMMessage, inChat chat: String) {
         self.ingest(item: item as ERTimeSortedParticipantsManagerIngestible, inChat: chat)
     }
-    
+
     func ingest(item: ERTimeSortedParticipantsManagerIngestible, inChat chat: String) {
         guard let sortRule = item.sortRule else {
             return
         }
-        
+
         self.ingest(rule: sortRule, inChat: chat)
     }
-    
+
     func ingest(items: [ERTimeSortedParticipantsManagerIngestible], inChat chat: String) {
         var rules = items.compactMap(\.sortRule)
-        
+
         rules.sort { r1, r2 in
             r1.lastSentMessageTime > r2.lastSentMessageTime
         }
-        
+
         rules = rules.removingDuplicates()
-        
+
         rules.forEach {
             self.ingest(rule: $0, inChat: chat)
         }
     }
-    
+
     func ingest(rule: ParticipantSortRule, inChat chat: String) {
         if chatToParticipantSortRules[chat] == nil {
             return
         }
-        
-        chatToParticipantSortRules[chat] = chatToParticipantSortRules[chat]!.filter {
-            $0.handleID != rule.handleID ? true : $0.lastSentMessageTime > rule.lastSentMessageTime
-        }.appending(rule)
-        
+
+        chatToParticipantSortRules[chat] = chatToParticipantSortRules[chat]!
+            .filter {
+                $0.handleID != rule.handleID ? true : $0.lastSentMessageTime > rule.lastSentMessageTime
+            }
+            .appending(rule)
+
         self.sortParticipants(forChat: chat)
     }
-    
+
     private func sortParticipants(forChat chat: String) {
-        self.chatToParticipantSortRules[chat]?.sort(by: { r1, r2 in
-            r1.lastSentMessageTime > r2.lastSentMessageTime
-        })
+        self.chatToParticipantSortRules[chat]?
+            .sort(by: { r1, r2 in
+                r1.lastSentMessageTime > r2.lastSentMessageTime
+            })
     }
-    
+
     public func unload(chatID: String) {
         self.chatToParticipantSortRules[chatID] = nil
     }
-    
-    public func bootstrap(chat: IMChat) -> Promise<Void> {
-        bootstrap(chats: [chat])
+
+    public func bootstrap(chat: IMChat) throws {
+        try bootstrap(chats: [chat])
     }
-    
-    public func bootstrap(chats: [IMChat]) -> Promise<Void> {
-        DBReader.shared.handleTimestampRecords(forChatIdentifiers: chats.compactMap { $0.chatIdentifier }).then { records in
-            self.chatToParticipantSortRules = records.map { record in
-                (record.chat_id, ParticipantSortRule(handleID: record.handle_id, lastSentMessageTime: Date.timeIntervalSince1970FromIMDBDateValue(date: Double(record.date))))
-            }.collectedDictionary(keyedBy: \.0, valuedBy: \.1)
-            
-            self.chatToParticipantSortRules.keys.forEach(self.sortParticipants(forChat:))
-        }
+
+    public func bootstrap(chats: [IMChat]) throws {
+        let records = try DBReader.shared.handleTimestampRecords(
+            forChatIdentifiers: chats.compactMap { $0.chatIdentifier }
+        )
+        chatToParticipantSortRules =
+            records.map { record in
+                (
+                    record.chat_id,
+                    ParticipantSortRule(
+                        handleID: record.handle_id,
+                        lastSentMessageTime: Date.timeIntervalSince1970FromIMDBDateValue(date: Double(record.date))
+                    )
+                )
+            }
+            .collectedDictionary(keyedBy: \.0, valuedBy: \.1)
+
+        chatToParticipantSortRules.keys.forEach(sortParticipants(forChat:))
     }
 }

--- a/Core/BarcelonaDB/Queries/HandleTimestamps.swift
+++ b/Core/BarcelonaDB/Queries/HandleTimestamps.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2021 Eric Rabil. All rights reserved.
 //
 
-import Foundation
 import BarcelonaFoundation
+import Foundation
 import GRDB
 import Logging
 
@@ -15,51 +15,51 @@ public typealias HandleTimestampRecord = (handle_id: String, date: Int64, chat_i
 
 private class HandleTimestampSynthesized: Record {
     override class var databaseTableName: String { "chat_message_join" }
-    
+
     required init(row: Row) {
         handle_id = row[Columns.handle_id]
         chat_id = row[Columns.chat_id]
         date = row[Columns.date]
         super.init(row: row)
     }
-    
+
     enum Columns: String, ColumnExpression {
         case handle_id, chat_id, date
     }
-    
+
     var handle_id: String
     var chat_id: String
     var date: Int64
-    
+
     /// Tuple used when sorting an array of handles for a chat
     var record: HandleTimestampRecord {
         (handle_id: handle_id, date: date, chat_id: chat_id)
     }
-    
+
 }
 
-private extension Array where Element == HandleTimestampSynthesized {
-    var records: [HandleTimestampRecord] {
+extension Array where Element == HandleTimestampSynthesized {
+    fileprivate var records: [HandleTimestampRecord] {
         map {
             $0.record
         }
     }
 }
 
-public extension DBReader {
+extension DBReader {
     /// Returns an arrya of handle/timestamp records used for sorting an array of chat participants
     /// - Parameter chatIDs: identifiers of the chats to pull participants for (typically this should just be identifiers for the same chat on different services)
     /// - Returns: array of handle/timestamp pairs
-    func handleTimestampRecords(forChatIdentifiers chatIDs: [String]) -> Promise<[HandleTimestampRecord]> {
-        read { db in
+    public func handleTimestampRecords(forChatIdentifiers chatIDs: [String]) throws -> [HandleTimestampRecord] {
+        try pool.read { db in
             let query: SQLRequest<HandleTimestampSynthesized> = """
-            SELECT DISTINCT handle.id AS handle_id, MAX(message.date) AS date, chat.chat_identifier AS chat_id FROM message
-            INNER JOIN handle ON message.handle_id = handle.ROWID
-            INNER JOIN chat_message_join ON message.ROWID = chat_message_join.message_id
-            INNER JOIN chat ON chat_message_join.chat_id = chat.ROWID AND chat.chat_identifier IN \(chatIDs)
-            GROUP BY handle_id, chat_identifier ORDER BY message.date DESC
-            """
-            
+                SELECT DISTINCT handle.id AS handle_id, MAX(message.date) AS date, chat.chat_identifier AS chat_id FROM message
+                INNER JOIN handle ON message.handle_id = handle.ROWID
+                INNER JOIN chat_message_join ON message.ROWID = chat_message_join.message_id
+                INNER JOIN chat ON chat_message_join.chat_id = chat.ROWID AND chat.chat_identifier IN \(chatIDs)
+                GROUP BY handle_id, chat_identifier ORDER BY message.date DESC
+                """
+
             return try query.fetchAll(db).map(\.record)
         }
     }

--- a/XCSpec/beeper.yaml
+++ b/XCSpec/beeper.yaml
@@ -38,6 +38,7 @@ targets:
         PRODUCT_NAME: barcelona-mautrix-${platform}
         PRODUCT_MODULE_NAME: barcelona_mautrix
         CREATE_INFOPLIST_SECTION_IN_BINARY: YES
+        MACOSX_DEPLOYMENT_TARGET: "13.0"
     info:
       path: ../Beeper/barcelona-mautrix/Info.plist
       properties:

--- a/XCSpec/templates.yaml
+++ b/XCSpec/templates.yaml
@@ -10,6 +10,7 @@ targetTemplates:
         PRODUCT_NAME: "$(TARGET_NAME:c99extidentifier)"
         VALID_ARCHS: "x86_64 arm64e arm64"
         SUPPORTED_PLATFORMS: "macosx iphonesimulator iphoneos"
+        MACOSX_DEPLOYMENT_TARGET: "13.0"
   BLTest:
     type: bundle.unit-test
     platform: macOS
@@ -18,10 +19,11 @@ targetTemplates:
         SWIFT_ACTIVE_COMPILATION_CONDITIONS: $(inherited) UNIT_TEST
         TEST_HOST: $(BUILT_PRODUCTS_DIR)/${test_host}.app/Contents/MacOS/${test_host}
         BUNDLE_LOADER: $(TEST_HOST)
+        MACOSX_DEPLOYMENT_TARGET: "13.0"
     postBuildScripts:
       - name: Codesign
         script: |
-            codesign -f -s "$CODE_SIGN_IDENTITY" --deep $BUILT_PRODUCTS_DIR/${test_host}.app/Contents/PlugIns/${target_name}.xctest
+          codesign -f -s "$CODE_SIGN_IDENTITY" --deep $BUILT_PRODUCTS_DIR/${test_host}.app/Contents/PlugIns/${target_name}.xctest
     dependencies:
       - target: ${test_host}
   BLTestHost:
@@ -35,5 +37,6 @@ targetTemplates:
       - ../Beeper/BarcelonaTestHost
     settings:
       CODE_SIGN_ENTITLEMENTS: ${entitlements}
+      MACOSX_DEPLOYMENT_TARGET: "13.0"
     dependencies:
       - package: XCTHarness


### PR DESCRIPTION
Use concurrency to ensure (currently non-perfect) memory safety when sorting participants.

This, and everything related to concurrency, will be a bit ugly until more of the codebase starts adapting it.