### PR TITLE
Use @MainActor to enforce main thread use

### DIFF
--- a/Beeper/BarcelonaMautrixIPC/Commands/Protocols/ChatResolvable.swift
+++ b/Beeper/BarcelonaMautrixIPC/Commands/Protocols/ChatResolvable.swift
@@ -15,6 +15,7 @@ protocol ChatResolvable {
 }
 
 extension ChatResolvable {
+    @MainActor
     var chat: IMChat? {
         if let chat = IMChatRegistry.shared.existingChat(withGUID: chat_guid) {
             return chat
@@ -36,7 +37,8 @@ extension ChatResolvable {
     var service: IMServiceStyle {
         ParsedGUID(rawValue: chat_guid).service == "iMessage" ? IMServiceStyle.iMessage : .SMS
     }
-    
+
+    @MainActor
     var cbChat: Chat? {
         guard let chat = chat else {
             return nil
@@ -45,6 +47,7 @@ extension ChatResolvable {
         return Chat(chat)
     }
     
+    @MainActor
     var blChat: BLChat? {
         chat?.blChat
     }

--- a/Beeper/BarcelonaMautrixIPC/Commands/Structs/BLMessage.swift
+++ b/Beeper/BarcelonaMautrixIPC/Commands/Structs/BLMessage.swift
@@ -99,7 +99,8 @@ public struct BLMessage: Codable, ChatResolvable {
     public var metadata: Message.Metadata?
     public var sender_correlation_id: String?
     public var correlation_id: String?
-    
+
+    @MainActor
     public init(message: Message) {
         guid = message.id
         timestamp = message.time / 1000 // mautrix-imessage expects this to be seconds

--- a/Beeper/BarcelonaMautrixIPC/Experimental/StartNewChat.swift
+++ b/Beeper/BarcelonaMautrixIPC/Experimental/StartNewChat.swift
@@ -85,6 +85,7 @@ public struct PrepareDMCommand: Codable {
 }
 
 extension PrepareDMCommand: Runnable {
+    @MainActor
     public func run(payload: IPCPayload, ipcChannel: MautrixIPCChannel) {
         let log = Logger(label: "ResolveIdentifierCommand")
         let transaction = SentrySDK.startTransaction(name: "prepare_dm", operation: "prepare_dm")

--- a/Beeper/BarcelonaMautrixIPC/IPCHandlers/BLHandlePayload.swift
+++ b/Beeper/BarcelonaMautrixIPC/IPCHandlers/BLHandlePayload.swift
@@ -46,6 +46,7 @@ private extension IPCPayload {
     }
 }
 
+@MainActor
 func BLHandlePayload(_ payload: IPCPayload, ipcChannel: MautrixIPCChannel) {
     guard let runnable = payload.runnable else {
         return log.warning("Received unhandleable payload type \(payload.command.name)")
@@ -58,7 +59,5 @@ func BLHandlePayload(_ payload: IPCPayload, ipcChannel: MautrixIPCChannel) {
         }
     }
 
-    DispatchQueue.main.async {
-        runnable.run(payload: payload, ipcChannel: ipcChannel)
-    }
+    runnable.run(payload: payload, ipcChannel: ipcChannel)
 }

--- a/Beeper/BarcelonaMautrixIPC/IPCHandlers/CommandHandlers/ChatOperations+Handler.swift
+++ b/Beeper/BarcelonaMautrixIPC/IPCHandlers/CommandHandlers/ChatOperations+Handler.swift
@@ -53,6 +53,7 @@ extension GetGroupChatInfoCommand: Runnable {
     var log: Logging.Logger {
         Logger(label: "TapbackCommand")
     }
+    @MainActor
     public func run(payload: IPCPayload, ipcChannel: MautrixIPCChannel) {
         log.info("Getting chat with id \(chat_guid)", source: "MautrixIPC")
         
@@ -68,6 +69,7 @@ extension SendReadReceiptCommand: Runnable, AuthenticatedAsserting {
     var log: Logging.Logger {
         Logger(label: "TapbackCommand")
     }
+    @MainActor
     public func run(payload: IPCPayload, ipcChannel: MautrixIPCChannel) {
         log.info("Sending read receipt to \(String(describing: cbChat?.blChatGUID))", source: "MautrixIPC")
 
@@ -80,6 +82,7 @@ extension SendReadReceiptCommand: Runnable, AuthenticatedAsserting {
 }
 
 extension SendTypingCommand: Runnable, AuthenticatedAsserting {
+    @MainActor
     public func run(payload: IPCPayload, ipcChannel: MautrixIPCChannel) {
         guard let chat = cbChat else {
             return payload.fail(strategy: .chat_not_found, ipcChannel: ipcChannel)
@@ -90,6 +93,7 @@ extension SendTypingCommand: Runnable, AuthenticatedAsserting {
 }
 
 extension GetGroupChatAvatarCommand: Runnable {
+    @MainActor
     public func run(payload: IPCPayload, ipcChannel: MautrixIPCChannel) {
         guard let chat = chat, let groupPhotoID = chat.groupPhotoID else {
             return payload.respond(.chat_avatar(nil), ipcChannel: ipcChannel)

--- a/Beeper/BarcelonaMautrixIPC/IPCHandlers/CommandHandlers/MessageQueries+Handler.swift
+++ b/Beeper/BarcelonaMautrixIPC/IPCHandlers/CommandHandlers/MessageQueries+Handler.swift
@@ -14,6 +14,7 @@ extension GetMessagesAfterCommand: Runnable, AuthenticatedAsserting {
     var log: Logging.Logger {
         Logger(label: "GetMessagesAfterCommand")
     }
+    @MainActor
     public func run(payload: IPCPayload, ipcChannel: MautrixIPCChannel) {
         log.debug("Getting messages for chat guid \(chat_guid) after time \(timestamp)")
         
@@ -37,6 +38,7 @@ extension GetMessagesAfterCommand: Runnable, AuthenticatedAsserting {
 }
 
 extension GetRecentMessagesCommand: Runnable, AuthenticatedAsserting {
+    @MainActor
     public func run(payload: IPCPayload, ipcChannel: MautrixIPCChannel) {
         if MXFeatureFlags.shared.mergedChats, chat_guid.starts(with: "SMS;") {
             return payload.respond(.messages([]), ipcChannel: ipcChannel)

--- a/Beeper/BarcelonaMautrixIPC/IPCHandlers/CommandHandlers/SendMediaMessageCommand+Handler.swift
+++ b/Beeper/BarcelonaMautrixIPC/IPCHandlers/CommandHandlers/SendMediaMessageCommand+Handler.swift
@@ -22,6 +22,7 @@ extension SendMediaMessageCommand: Runnable, AuthenticatedAsserting {
     var log: Logging.Logger {
         Logger(label: "SendMediaMessageCommand")
     }
+    @MainActor
     public func run(payload: IPCPayload, ipcChannel: MautrixIPCChannel) {
         guard let chat = cbChat, let imChat = chat.imChat else {
             return payload.fail(strategy: .chat_not_found, ipcChannel: ipcChannel)

--- a/Beeper/BarcelonaMautrixIPC/IPCHandlers/CommandHandlers/SendMessageCommand+Handler.swift
+++ b/Beeper/BarcelonaMautrixIPC/IPCHandlers/CommandHandlers/SendMessageCommand+Handler.swift
@@ -14,6 +14,7 @@ import Logging
 private let log = Logger(label: "SendMessageCommand")
 
 extension SendMessageCommand: Runnable, AuthenticatedAsserting {
+    @MainActor
     public func run(payload: IPCPayload, ipcChannel: MautrixIPCChannel) {
         guard let chat = cbChat, let imChat = chat.imChat else {
             return payload.fail(strategy: .chat_not_found, ipcChannel: ipcChannel)
@@ -42,7 +43,6 @@ extension SendMessageCommand: Runnable, AuthenticatedAsserting {
             
             if isRichLink, let url = rich_link?.originalURL ?? rich_link?.URL ?? richLinkURL {
                 var threadError: Error?
-                Thread.main.sync ({
                     log.debug("I am processing a rich link! text '\(text)'", source: "BLMautrix")
                     
                     let message = ERCreateBlankRichLinkMessage(text.trimmingCharacters(in: [" "]), url) { item in
@@ -71,7 +71,6 @@ extension SendMessageCommand: Runnable, AuthenticatedAsserting {
                     imChat.send(message)
                     afterSend()
                     finalMessage = Message(ingesting: message, context: IngestionContext(chatID: chat.id, service: service))!
-                } as @convention(block) () -> ())
                 if let threadError = threadError {
                     throw threadError
                 }

--- a/Beeper/BarcelonaMautrixIPC/IPCHandlers/CommandHandlers/SendTapbackCommand+Handler.swift
+++ b/Beeper/BarcelonaMautrixIPC/IPCHandlers/CommandHandlers/SendTapbackCommand+Handler.swift
@@ -14,6 +14,7 @@ extension TapbackCommand: Runnable, AuthenticatedAsserting {
     var log: Logging.Logger {
         Logger(label: "TapbackCommand")
     }
+    @MainActor
     public func run(payload: IPCPayload, ipcChannel: MautrixIPCChannel) {
         guard let chat = cbChat else {
             return payload.fail(strategy: .chat_not_found, ipcChannel: ipcChannel)

--- a/Beeper/BarcelonaMautrixIPC/Runtime/BLPayloadReader.swift
+++ b/Beeper/BarcelonaMautrixIPC/Runtime/BLPayloadReader.swift
@@ -16,7 +16,8 @@ public class BLPayloadReader {
     private var queue = [IPCPayload]()
     
     private var bag = Set<AnyCancellable>()
-    
+
+    @MainActor
     public init(ipcChannel: MautrixIPCChannel) {
         self.ipcChannel = ipcChannel
         
@@ -36,7 +37,8 @@ public class BLPayloadReader {
             self.ready = true
         }
     }
-    
+
+    @MainActor
     public var ready = false {
         didSet {
             let queue = queue

--- a/Beeper/barcelona-mautrix/BarcelonaMautrix.swift
+++ b/Beeper/barcelona-mautrix/BarcelonaMautrix.swift
@@ -17,11 +17,13 @@ import Logging
 private let log = Logger(label: "BarcelonaMautrix")
 
 @main
+@MainActor
 class BarcelonaMautrix {
     private let mautrixIPCChannel: MautrixIPCChannel
     private let reader: BLPayloadReader
     private let eventHandler: BLEventHandler
-    
+
+    @MainActor
     init(_ mautrixIPCChannel: MautrixIPCChannel) {
         self.mautrixIPCChannel = mautrixIPCChannel
         reader = BLPayloadReader(ipcChannel: mautrixIPCChannel)
@@ -78,14 +80,14 @@ class BarcelonaMautrix {
         
         barcelonaMautrix.run()
     }
-    
+
     func run() {
         checkArguments()
         bootstrap()
         
         RunLoop.main.run()
     }
-    
+
     func bootstrap() {
         log.info("Bootstrapping")
         

--- a/Core/Barcelona/Barcelona/BLBlocklistController.swift
+++ b/Core/Barcelona/Barcelona/BLBlocklistController.swift
@@ -11,6 +11,7 @@ public class BLBlocklistController {
     @_spi(unitTestInternals) public var testingOverride: Set<String> = Set()
 }
 
+@MainActor
 public extension BLBlocklistController {
     static let shared = BLBlocklistController()
     

--- a/Core/Barcelona/Barcelona/BLMediaMessageMontior.swift
+++ b/Core/Barcelona/Barcelona/BLMediaMessageMontior.swift
@@ -14,6 +14,7 @@ import Logging
 
 fileprivate let log = Logger(label: "MessageMonitor")
 
+@MainActor
 public class BLMediaMessageMonitor {
     public let messageID: () -> String
     public let transferGUIDs: [String]

--- a/Core/Barcelona/Barcelona/BLMessageExpert.swift
+++ b/Core/Barcelona/Barcelona/BLMessageExpert.swift
@@ -11,6 +11,7 @@ import IMFoundation
 import Logging
 
 /// The BLMessageExpert offers a simplified API for monitoring message state events
+@MainActor
 public class BLMessageExpert {
     public static let shared = BLMessageExpert()
     
@@ -89,8 +90,8 @@ public class BLMessageExpert {
     public let eventPipeline = CBPipeline<BLMessageEvent>()
     
     public init() {
-        CBDaemonListener.shared.messageStatusPipeline.pipe { change in self.queue.async { self.process(change: change) } }
-        CBDaemonListener.shared.messagePipeline.pipe { message in self.queue.async { self.process(message: message) } }
+        CBDaemonListener.shared.messageStatusPipeline.pipe { change in  { self.process(change: change) } }
+        CBDaemonListener.shared.messagePipeline.pipe { message in { self.process(message: message) } }
         seenMessages.reserveCapacity(100)
     }
     
@@ -101,8 +102,7 @@ public class BLMessageExpert {
     
     private var counter: Int = 0
     private var seenMessages: [String: BLMessageEventReceipt] = [:]
-    private let queue: DispatchQueue = DispatchQueue(label: "BLMessageExpert")
-    
+
     private func send(_ event: BLMessageEvent) {
         if seenMessages[event.id]?.event == event {
             return

--- a/Core/Barcelona/CoreBarcelona/CBFeatureFlags.swift
+++ b/Core/Barcelona/CoreBarcelona/CBFeatureFlags.swift
@@ -16,6 +16,7 @@ private let isDebugBuild = false
 
 // to enable something off by default, --enable-
 // to disable, --disable-
+@MainActor
 public class _CBFeatureFlags: FlagProvider {
     // Supported way of overriding defaults, manipulate this early on since things are cached agressively
     public struct Defaults {
@@ -125,6 +126,7 @@ extension String {
 }
 
 @dynamicMemberLookup
+@MainActor
 public class _CBLoggingFlags: FlagProvider {
     private var cache: [String: FeatureFlag] = [:]
 
@@ -144,9 +146,12 @@ public class _CBLoggingFlags: FlagProvider {
     }
 }
 
+@MainActor
 public let CBFeatureFlags = _CBFeatureFlags()
+@MainActor
 public let CBLoggingFlags = _CBLoggingFlags()
 
+@MainActor
 @_transparent internal func ifInternal(_ block: () -> ()) {
     if CBFeatureFlags.internalDiagnostics {
         block()

--- a/Core/Barcelona/CoreBarcelona/CBFileTransfer.swift
+++ b/Core/Barcelona/CoreBarcelona/CBFileTransfer.swift
@@ -12,6 +12,7 @@ import Logging
 
 /// Registers a file transfer with imagent for the given filename and path.
 /// The returned file transfer is ready to be sent by including its GUID in a message.
+@MainActor
 public func CBInitializeFileTransfer(filename: String, path: URL) -> IMFileTransfer {
     let log = Logger(label: "CBInitializeFileTransfer")
     var transfer: IMFileTransfer!

--- a/Core/Barcelona/CoreBarcelona/CBSenderCorrelationController.swift
+++ b/Core/Barcelona/CoreBarcelona/CBSenderCorrelationController.swift
@@ -105,6 +105,7 @@ public extension CBSenderCorrelationController {
 prefix operator ~
 
 @_transparent
+@MainActor
 private prefix func ~(_ expression: @autoclosure () -> ()) {
     if _fastPath(!CBSenderCorrelationController.debug) {
         return
@@ -113,6 +114,7 @@ private prefix func ~(_ expression: @autoclosure () -> ()) {
 }
 
 /// Tracks the correlation of different sender IDs to a single, unique identity representing an Apple ID
+@MainActor
 public class CBSenderCorrelationController {
     private class Stack {
         let log = Logger(label: "CBSenderCorrelationController.Stack")
@@ -590,6 +592,7 @@ extension Message: CBSenderTargetable {
     }
 }
 
+@MainActor
 extension IMChat {
     /// Returns other chats with the same sender correlation ID
     public var siblings: [IMChat] {
@@ -650,6 +653,7 @@ internal extension CBCorrelationOverrideController {
 
 import SwiftCLI
 
+@MainActor
 public class CBCorrelationCommands: CommandGroup {
     public let name: String = "correlation"
     public let shortDescription: String = "interact with the correlation subsystem"
@@ -665,7 +669,9 @@ public class CBCorrelationCommands: CommandGroup {
         @Param public var sender: String
         
         public func execute() throws {
-            print(CBSenderCorrelationController.shared.correlate(senderID: sender))
+            DispatchQueue.main.sync {
+                print(CBSenderCorrelationController.shared.correlate(senderID: sender))
+            }
         }
     }
     

--- a/Core/Barcelona/CoreBarcelona/Paris/CBChat+MessageHandling.swift
+++ b/Core/Barcelona/CoreBarcelona/Paris/CBChat+MessageHandling.swift
@@ -14,7 +14,9 @@ import IMSharedUtilities
 
 private let log = Logger(label: "CBChat")
 
+@MainActor
 public extension CBChat {
+
     enum MessageInput: CustomDebugStringConvertible, CustomStringConvertible {
         #if canImport(IMSharedUtilities)
         case item(IMItem)
@@ -30,6 +32,7 @@ public extension CBChat {
             }
         }
         
+        @MainActor
         public func handle(message: inout CBMessage?, leaf: CBChatIdentifier) -> CBMessage {
             switch self {
                 #if canImport(IMSharedUtilities)

--- a/Core/Barcelona/CoreBarcelona/Paris/CBChat.swift
+++ b/Core/Barcelona/CoreBarcelona/Paris/CBChat.swift
@@ -12,6 +12,7 @@ import IMSharedUtilities
 import Logging
 
 /// An entity tracking a single logical conversation comprised of potentially several different chats
+@MainActor
 public class CBChat {
     private let log = Logger(label: "CBChat")
     /// All cached messages for this chat

--- a/Core/Barcelona/CoreBarcelona/Paris/CBChatLeaf.swift
+++ b/Core/Barcelona/CoreBarcelona/Paris/CBChatLeaf.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 /// Metadata for a single chat tracked by a logical conversation
+@MainActor
 public struct CBChatLeaf {
     /// The GUID for this chat
     public var guid: String = ""

--- a/Core/Barcelona/CoreBarcelona/Paris/CBChatRegistry.swift
+++ b/Core/Barcelona/CoreBarcelona/Paris/CBChatRegistry.swift
@@ -30,6 +30,7 @@ public class CBChatRegistry: NSObject, IMDaemonListenerProtocol {
         IMDaemonController.shared().listener.addHandler(self)
     }
     
+    @MainActor
     public func setupComplete(_ success: Bool, info: [AnyHashable : Any]!) {
         if let chats = info["personMergedChats"] as? [[AnyHashable: Any]] {
             for chat in chats {
@@ -40,11 +41,13 @@ public class CBChatRegistry: NSObject, IMDaemonListenerProtocol {
         }
     }
     
+    @MainActor
     public func chat(_ persistentIdentifier: String!, updated updateDictionary: [AnyHashable : Any]!) {
         trace(nil, nil, "persistentIdentifier \(persistentIdentifier!) updated \(((updateDictionary ?? [:]) as NSDictionary))")
         _ = handle(chat: updateDictionary)
     }
-    
+
+    @MainActor
     public func chat(_ persistentIdentifier: String!, propertiesUpdated properties: [AnyHashable : Any]!) {
         trace(nil, nil, "persistentIdentifier \(persistentIdentifier!) properties \(((properties ?? [:]) as NSDictionary))")
         _ = handle(chat: [
@@ -63,6 +66,7 @@ public class CBChatRegistry: NSObject, IMDaemonListenerProtocol {
     
     var loadedChatsByChatIdentifierCallback: [String: [([IMChat]) -> ()]] = [:]
     
+    @MainActor
     public func chatLoaded(withChatIdentifier chatIdentifier: String!, chats chatDictionaries: [Any]!) {
         trace(chatIdentifier, nil, "chats loaded: \((chatDictionaries as NSArray))")
         guard let callbacks = loadedChatsByChatIdentifierCallback.removeValue(forKey: chatIdentifier) else {
@@ -78,6 +82,7 @@ public class CBChatRegistry: NSObject, IMDaemonListenerProtocol {
         trace(nil, nil, "loaded last message for all chats \((chatIDToLastMessageDictionary as NSDictionary))")
     }
     
+    @MainActor
     public func service(_ serviceID: String!, chat chatIdentifier: String!, style chatStyle: IMChatStyle, messagesUpdated messages: [[AnyHashable: Any]]!) {
         trace(chatIdentifier, nil, "messages updated \(messages.debugDescription)")
         messages.forEach {
@@ -89,6 +94,7 @@ public class CBChatRegistry: NSObject, IMDaemonListenerProtocol {
         trace(chatIdentifier, nil, "error \((error as NSError).debugDescription)")
     }
     
+    @MainActor
     public func account(_ accountUniqueID: String!, chat chatIdentifier: String!, style chatStyle: IMChatStyle, chatProperties properties: [AnyHashable : Any]!, notifySentMessage msg: IMMessageItem!, sendTime: NSNumber!) {
         trace(chatIdentifier, nil, "sent message \(msg.guid ?? "nil") \(msg.debugDescription)")
         handle(chatIdentifier: chatIdentifier, properties: properties, groupID: nil, item: msg)
@@ -98,6 +104,7 @@ public class CBChatRegistry: NSObject, IMDaemonListenerProtocol {
         log.debug("chat \(chatIdentifier ?? "nil") pcID \(personCentricID ?? "nil") \(message): \(function.description)")
     }
     
+    @MainActor
     public func account(_ accountUniqueID: String!, chat chatIdentifier: String!, style chatStyle: IMChatStyle, chatProperties properties: [AnyHashable : Any]!, groupID: String!, chatPersonCentricID personCentricID: String!, messagesReceived messages: [IMItem]!, messagesComingFromStorage fromStorage: Bool) {
         trace(chatIdentifier, personCentricID, "received \(messages!) from storage \(fromStorage)")
         messages.forEach {
@@ -109,6 +116,7 @@ public class CBChatRegistry: NSObject, IMDaemonListenerProtocol {
         
     }
     
+    @MainActor
     public func account(_ accountUniqueID: String!, chat chatIdentifier: String!, style chatStyle: IMChatStyle, chatProperties properties: [AnyHashable : Any]!, groupID: String!, chatPersonCentricID personCentricID: String!, messagesReceived messages: [IMItem]!) {
         trace(chatIdentifier, personCentricID, "received \(messages!)")
         messages.forEach {
@@ -116,11 +124,13 @@ public class CBChatRegistry: NSObject, IMDaemonListenerProtocol {
         }
     }
     
+    @MainActor
     public func account(_ accountUniqueID: String!, chat chatIdentifier: String!, style chatStyle: IMChatStyle, chatProperties properties: [AnyHashable : Any]!, groupID: String!, chatPersonCentricID personCentricID: String!, messageReceived msg: IMItem!) {
         trace(chatIdentifier, personCentricID, "received message \(msg.debugDescription)")
         handle(chatIdentifier: chatIdentifier, properties: properties, groupID: groupID, item: msg)
     }
     
+    @MainActor
     private func handle(chatIdentifier: String?, properties: [AnyHashable: Any]?, groupID: String?, item: NSObject) {
         lazy var guid: String? = {
             switch item {
@@ -183,6 +193,7 @@ public class CBChatRegistry: NSObject, IMDaemonListenerProtocol {
         handle(chat: chatID, item: item)
     }
     
+    @MainActor
     public func account(_ accountUniqueID: String!, chat chatIdentifier: String!, style chatStyle: IMChatStyle, chatProperties properties: [AnyHashable : Any]!, groupID: String!, chatPersonCentricID personCentricID: String!, messageSent msg: IMMessageItem!) {
         trace(chatIdentifier, personCentricID, "sent message \(msg)")
         handle(chatIdentifier: chatIdentifier, properties: properties, groupID: groupID, item: msg)
@@ -192,11 +203,13 @@ public class CBChatRegistry: NSObject, IMDaemonListenerProtocol {
         trace(chatIdentifier, nil, "properties \(((properties ?? [:]) as NSDictionary)) updated to \(((update ?? [:]) as NSDictionary))")
     }
     
+    @MainActor
     public func account(_ accountUniqueID: String!, chat chatIdentifier: String!, style chatStyle: IMChatStyle, chatProperties properties: [AnyHashable : Any]!, messageUpdated msg: IMItem!) {
         trace(chatIdentifier, nil, "message updated \(msg)")
         handle(chatIdentifier: chatIdentifier, properties: properties, groupID: nil, item: msg)
     }
     
+    @MainActor
     public func account(_ accountUniqueID: String!, chat chatIdentifier: String!, style chatStyle: IMChatStyle, chatProperties properties: [AnyHashable : Any]!, messagesUpdated messages: [NSObject]!) {
         trace(chatIdentifier, nil, "messages updated \((messages! as NSArray))")
         messages.forEach {
@@ -206,6 +219,7 @@ public class CBChatRegistry: NSObject, IMDaemonListenerProtocol {
     
     var queryCallbacks: [String: [() -> ()]] = [:]
     
+    @MainActor
     private func internalize(chats: [[AnyHashable: Any]]) -> [IMChat] {
         func getMutableDictionary(_ key: String) -> NSMutableDictionary {
             if let dict = IMChatRegistry.shared.value(forKey: key) as? NSMutableDictionary {
@@ -272,6 +286,7 @@ public class CBChatRegistry: NSObject, IMDaemonListenerProtocol {
         }
     }
     
+    @MainActor
     public func loadedChats(_ chats: [[AnyHashable : Any]]!, queryID: String!) {
         guard queryCallbacks.keys.contains(queryID) else {
             return
@@ -285,6 +300,7 @@ public class CBChatRegistry: NSObject, IMDaemonListenerProtocol {
     var hasLoadedChats = false
     @Atomic var loadedChatsCallbacks: [() -> ()] = []
     
+    @MainActor
     public func loadedChats(_ chats: [[AnyHashable : Any]]!) {
         _ = internalize(chats: chats)
         let loadedChatsCallbacks = self.loadedChatsCallbacks
@@ -303,6 +319,7 @@ public class CBChatRegistry: NSObject, IMDaemonListenerProtocol {
     }
 }
 
+@MainActor
 public extension CBChatRegistry {
     static let shared = CBChatRegistry()
     
@@ -391,6 +408,7 @@ public extension CBChatRegistry {
 }
 
 #if canImport(IMSharedUtilities)
+@MainActor
 public extension CBChatRegistry {
     func handle(chat: [AnyHashable: Any], item: IMItem) -> Bool {
         guard let identifier = handle(chat: chat).1 else {

--- a/Core/Barcelona/CoreBarcelona/Paris/CBMessage.swift
+++ b/Core/Barcelona/CoreBarcelona/Paris/CBMessage.swift
@@ -35,6 +35,7 @@ public struct CBMessage: Codable, CustomDebugStringConvertible {
     public var flags: Flags = .none
     
     /// Initializes the message from a dictionary representation
+    @MainActor
     public init?(dictionary: [AnyHashable: Any], chat: CBChatIdentifier) {
         guard let id = dictionary["guid"] as? String else {
             return nil
@@ -45,6 +46,7 @@ public struct CBMessage: Codable, CustomDebugStringConvertible {
     }
     
     /// Updates the sender and timestamps according to the person who triggered the update
+    @MainActor
     public mutating func handle(time: Date?, timeDelivered: Date?, timeRead: Date?, sender deltaSender: CBSender) -> CBMessage {
         if flags.contains(.fromMe) {
             if deltaSender.scheme != .me {
@@ -65,6 +67,7 @@ public struct CBMessage: Codable, CustomDebugStringConvertible {
     }
     
     /// Updates the message using a dictionary representation
+    @MainActor
     @discardableResult public mutating func handle(dictionary: [AnyHashable: Any]) -> CBMessage {
         service = (dictionary["service"] as? String).flatMap(CBServiceName.init(rawValue:)) ?? service
         error = (dictionary["error"] as? UInt32).flatMap(FZErrorType.init(rawValue:)) ?? error
@@ -75,6 +78,7 @@ public struct CBMessage: Codable, CustomDebugStringConvertible {
         return handle(time: extractTime("time"), timeDelivered: extractTime("timeDelivered"), timeRead: extractTime("timeRead"), sender: CBSender(dictionary: dictionary))
     }
     
+    @MainActor
     private mutating func updated() -> CBMessage {
         if eligibleToResend {
             let id = id
@@ -309,6 +313,7 @@ extension CBMessage.Flags {
     
 }
 
+@MainActor
 public extension CBMessage {
     /// Initializes the message using an `IMItem` instance
     @_disfavoredOverload init(item: IMItem, chat: CBChatIdentifier) {
@@ -372,6 +377,7 @@ extension CBMessage {
     }
 }
 
+@MainActor
 public extension CBMessage {
     var eligibleToResend: Bool {
         guard flags.contains(.fromMe) else {

--- a/Core/Barcelona/CoreBarcelona/Support/ERBaseIDSListener.swift
+++ b/Core/Barcelona/CoreBarcelona/Support/ERBaseIDSListener.swift
@@ -114,11 +114,10 @@ enum IDSCommandID: NSInteger, CaseIterable, Codable {
     case commandResponse = 255
 }
 
-public class ERBaseIDSListener: NSObject, IDSDaemonListenerProtocol {    
+public class ERBaseIDSListener: NSObject, IDSDaemonListenerProtocol {
+    @MainActor
     public func daemonConnected() {
-        DispatchQueue.main.async {
-            BLDaemon.shared.initialize()
-        }
+        BLDaemon.shared.initialize()
     }
     
     public func messageReceived(_ arg1: [AnyHashable : Any]!, withGUID arg2: String!, withPayload arg3: [AnyHashable : Any]!, forTopic arg4: String!, toIdentifier arg5: String!, fromID arg6: String!, context arg7: [AnyHashable : Any]!) {

--- a/Core/Barcelona/Extensions/Fun/Chat+@everyone.swift
+++ b/Core/Barcelona/Extensions/Fun/Chat+@everyone.swift
@@ -17,7 +17,8 @@ public extension Chat {
     enum AtEveryoneError: Error {
         case textTooShort
     }
-    
+
+    @MainActor
     func pingEveryone(text: String) throws -> Message {
         let targetParticipants = participants.filter {
             !$0.cb_isOneOfMyHandles

--- a/Core/Barcelona/Extensions/Glue/IMChat+ForceRefresh.swift
+++ b/Core/Barcelona/Extensions/Glue/IMChat+ForceRefresh.swift
@@ -11,6 +11,7 @@ import Logging
 
 private let log = Logger(label: "IMChat")
 
+@MainActor
 public extension IMChat {
     /// Returns true if the next message sent will be sent over SMS
     var willSendSMS: Bool {

--- a/Core/Barcelona/Extensions/Glue/IMChat+TimeSortedParticipants.swift
+++ b/Core/Barcelona/Extensions/Glue/IMChat+TimeSortedParticipants.swift
@@ -24,12 +24,14 @@ extension Array where Element: Hashable {
 }
 
 public extension IMChat {
+    @MainActor
     fileprivate var cachedRecentParticipantHandleIDs: [String] {
         ERTimeSortedParticipantsManager.sharedInstance.sortedParticipants(forChat: self.id)
             .filter(self.participantHandleIDs().contains)
             .removingDuplicates()
     }
     
+    @MainActor
     var recentParticipantHandleIDs: [String] {
         var cachedRecent = cachedRecentParticipantHandleIDs
         

--- a/Core/Barcelona/Extensions/Glue/LPExternalProvider.swift
+++ b/Core/Barcelona/Extensions/Glue/LPExternalProvider.swift
@@ -148,7 +148,8 @@ public extension IMMessage {
             }
         }
     }
-    
+
+    @MainActor
     func loadLinkMetadata(at url: URL) {
         guard let dataSource = decodePluginDataSource() else {
             return
@@ -156,54 +157,20 @@ public extension IMMessage {
         guard let richLinkDataSource = dataSource.richLinkDataSource else {
             return
         }
-        
-        func _load() {
-            let metadata = LPLinkMetadata()
-            metadata.originalURL = url
-            richLinkDataSource.richLink.isPlaceholder = true
-            richLinkDataSource.richLink.metadata = metadata
-            richLinkDataSource.richLink.needsCompleteFetch = true
-            richLinkDataSource.richLink.needsSubresourceFetch = true
-            dataSource.setValue(url, forKey: "originalURL")
-            dataSource.payloadWillSendFromShelf()
-            richLinkDataSource._startFetchingMetadata()
-            IMMessage.retains[self] = .init(arrayLiteral: metadata, dataSource)
-            onceSent().then {
-                IMMessage.retains.removeValue(forKey: self)
-            }
-        }
 
-        if Thread.isMainThread {
-            _load()
-        } else {
-            DispatchQueue.main.sync(execute: _load)
+        let metadata = LPLinkMetadata()
+        metadata.originalURL = url
+        richLinkDataSource.richLink.isPlaceholder = true
+        richLinkDataSource.richLink.metadata = metadata
+        richLinkDataSource.richLink.needsCompleteFetch = true
+        richLinkDataSource.richLink.needsSubresourceFetch = true
+        dataSource.setValue(url, forKey: "originalURL")
+        dataSource.payloadWillSendFromShelf()
+        richLinkDataSource._startFetchingMetadata()
+        IMMessage.retains[self] = .init(arrayLiteral: metadata, dataSource)
+        onceSent().then {
+            IMMessage.retains.removeValue(forKey: self)
         }
-        
-//        let sentPromise = onceSent()
-//        DispatchQueue.main.async {
-//            guard let provider = LPMetadataProvider() else {
-//                return
-//            }
-//            IMMessage.fetchers[self] = provider
-//            provider.startFetchingMetadata(for: url) { metadata, error in
-//                IMMessage.fetchers.removeValue(forKey: self)
-//                guard let metadata = metadata else {
-//                    return
-//                }
-//                sentPromise.then {
-//                    richLinkDataSource.updateRichLink(with: metadata)
-//                    richLinkDataSource.dispatchDidReceiveMetadataToAllClients()
-//                    var attachments: NSArray?
-//                    self.payloadData = richLinkDataSource.richLink.dataRepresentation(withOutOfLineAttachments: &attachments)
-//                    dataSource.sendPayload(self.payloadData, attachments: attachments)
-//                    if let attachments = attachments {
-//                        let transferGUIDs = IMFileTransferCenter.sharedInstance().guids(forStoredAttachmentPayloadData: attachments, messageGUID: self.guid) as? [String] ?? []
-//                        self.fileTransferGUIDs = transferGUIDs
-//                        self._imMessageItem.fileTransferGUIDs = transferGUIDs
-//                    }
-//                }
-//            }
-//        }
     }
     
     func provideLinkMetadata(_ metadata: RichLinkMetadata) throws -> () -> () {

--- a/Core/Barcelona/Extensions/MessageSearching/IMMessage+SPI.swift
+++ b/Core/Barcelona/Extensions/MessageSearching/IMMessage+SPI.swift
@@ -35,11 +35,13 @@ public extension IMMessage {
     static func message(fromUnloadedItem item: IMMessageItem) -> IMMessage? {
         message(fromUnloadedItem: item, withSubject: nil)
     }
-    
+
+    @MainActor
     static func message(withGUID guid: String, in chat: String? = nil, service: IMServiceStyle) -> Promise<ChatItem?> {
         return messages(withGUIDs: [guid], in: chat, service: service).then(\.first)
     }
-    
+
+    @MainActor
     static func messages(withGUIDs guids: [String], in chat: String? = nil, service: IMServiceStyle) -> Promise<[ChatItem]> {
         if guids.count == 0 {
             return .success([])

--- a/Core/Barcelona/Extensions/Tapbacks/IMChat+Acknowledgment.swift
+++ b/Core/Barcelona/Extensions/Tapbacks/IMChat+Acknowledgment.swift
@@ -17,13 +17,10 @@ public extension IMChat {
     /**
      Sends a tapback for a given message, calling back with a Vapor abort if the operation fails. This must be invoked on the main thread.
      */
+    @MainActor
     func tapback(guid: String, itemGUID: String, type: Int, overridingItemType: UInt8?, metadata: Message.Metadata? = nil) throws -> IMMessage {
         guard let message = BLLoadIMMessage(withGUID: guid) else {
             throw BarcelonaError(code: 404, message: "Unknown message: \(guid)")
-        }
-
-        guard Thread.isMainThread else {
-            preconditionFailure("IMChat.tapback() must be invoked on the main thread")
         }
 
         let correctGUID: String = {

--- a/Core/Barcelona/IMCoreHelpers/BarcelonaManager.swift
+++ b/Core/Barcelona/IMCoreHelpers/BarcelonaManager.swift
@@ -89,6 +89,7 @@ public func BLTeardown() {
 }
 
 @_cdecl("BLBootstrapController")
+@MainActor
 public func BLBootstrapController(_ callbackC: (@convention(c) (Bool) -> ())? = nil, _ callbackSwift: ((Bool) -> ())? = nil) -> Bool {
     guard BLSwizzleDaemonController() else {
         callbackC?(false)
@@ -155,6 +156,7 @@ public func BLBootstrapController(_ callbackC: (@convention(c) (Bool) -> ())? = 
     return true
 }
 
+@MainActor
 public class BarcelonaManager {
     public static let shared = BarcelonaManager()
     

--- a/Core/Barcelona/IMCoreHelpers/ERTimeSortedParticipantsManager.swift
+++ b/Core/Barcelona/IMCoreHelpers/ERTimeSortedParticipantsManager.swift
@@ -175,14 +175,16 @@ public class ERTimeSortedParticipantsManager {
                     "Finished recomputing sorted participants with chat ID \(chat.id) per notification \(notification.name.rawValue)"
                 )
             } catch {
-                log.error("Error ")
+                log.error("Error \(error)")
             }
         }
     }
 
+    @MainActor
     private var chatToParticipantSortRules: [String: [ParticipantSortRule]] = [:]
 
 
+    @MainActor
     public func sortedParticipants(forChat chat: String) -> [String] {
         chatToParticipantSortRules[chat]?.map(\.handleID) ?? []
     }

--- a/Core/Barcelona/IMCoreHelpers/RegressionTesting.swift
+++ b/Core/Barcelona/IMCoreHelpers/RegressionTesting.swift
@@ -34,6 +34,7 @@ public extension BLRegressionTesting {
 }
 
 // Testing methods
+@MainActor
 fileprivate extension IMChat {
     func forceToSMS() {
         _setAccount(IMAccountController.shared.activeSMSAccount, locally: false)
@@ -45,6 +46,7 @@ fileprivate extension IMChat {
 
 import IMCore
 
+@MainActor
 public extension BLRegressionTesting {
     static let tests: [String: () -> ()] = [
         "BRI4482": BRI4482,
@@ -59,7 +61,7 @@ public extension BLRegressionTesting {
                     queue.schedule {
                         let group = DispatchGroup()
                         group.enter()
-                        DispatchQueue.global().async {
+                        DispatchQueue.main.async {
                             print(">>> Raw history query for \(chat.chatIdentifiers.joined(separator: ","))")
                             chat.rawHistoryQuery(limit: 10).forEach { chat, message in
                                 guard chat.scheme == .chatIdentifier else {
@@ -109,7 +111,7 @@ public extension BLRegressionTesting {
             print(chat.chatForSending(with: guid).debugDescription)
         }
     ]
-    
+
     static func BRI4482() {
         guard let smsEmailHandle = handles.first(where: {
             $0.id.isEmail && $0.service?.id == .SMS

--- a/Core/Barcelona/Queries/IMDPersistence.swift
+++ b/Core/Barcelona/Queries/IMDPersistence.swift
@@ -148,6 +148,7 @@ private func BLCreateIMMessageFromIMDMessageRecordRefs(_ refs: NSArray) -> [IMMe
 ///   - refs: the refs to parse
 ///   - chat: the ID of the chat the messages reside in. if omitted, the chat ID will be resolved at ingestion
 /// - Returns: An NIO future of ChatItems
+@MainActor
 private func BLIngestIMDMessageRecordRefs(_ refs: NSArray, in chat: String? = nil, service: IMServiceStyle) -> Promise<[ChatItem]> {
     if refs.count == 0 {
         return .success([])
@@ -213,6 +214,7 @@ public func BLLoadIMMessage(withGUID guid: String) -> IMMessage? {
 ///   - guids: GUIDs of messages to load
 ///   - chat: ID of the chat to load. if omitted, it will be resolved at ingestion.
 /// - Returns: NIO future of ChatItems
+@MainActor
 public func BLLoadChatItems(withGUIDs guids: [String], chatID: String? = nil, service: IMServiceStyle) -> Promise<[ChatItem]> {
     if guids.count == 0 {
         return .success([])
@@ -229,6 +231,7 @@ public func BLLoadChatItems(withGUIDs guids: [String], chatID: String? = nil, se
     return IMDPersistenceMarshal.putBuffers(guids, BLIngestIMDMessageRecordRefs(refs, in: chatID, service: service)) + buffer
 }
 
+@MainActor
 public func BLLoadChatItems(withGraph graph: [String: ([String], IMServiceStyle)]) -> Promise<[ChatItem]> {
     if graph.count == 0 {
         return .success([])
@@ -261,6 +264,7 @@ public func BLLoadChatItems(withGraph graph: [String: ([String], IMServiceStyle)
 ///   - beforeGUID: GUID of the message all messages must precede
 ///   - limit: max number of messages to return
 /// - Returns: NIO future of ChatItems
+@MainActor
 public func BLLoadChatItems(withChats chats: [(id: String, service: IMServiceStyle)], afterDate: Date? = nil, beforeDate: Date? = nil, afterGUID: String? = nil, beforeGUID: String? = nil, limit: Int? = nil) -> Promise<[ChatItem]> {
     // We turn the list of chats into just a list of chatIdentifiers
     let chatIdentifiers = chats.map(\.0)

--- a/Core/Barcelona/Wrappers/BLIngest-Internal.swift
+++ b/Core/Barcelona/Wrappers/BLIngest-Internal.swift
@@ -35,6 +35,7 @@ extension IMMessage: IMItemIDResolvable {
 
 // MARK: - IMFileTransfer Preload
 @inlinable
+@MainActor
 internal func _BLLoadFileTransfers(forObjects objects: [NSObject]) -> Promise<Void> {
     let log = Logger(label: "_BLLoadFileTransfers")
     let unloadedFileTransferGUIDs = objects.compactMap {

--- a/Core/Barcelona/Wrappers/BLIngest.swift
+++ b/Core/Barcelona/Wrappers/BLIngest.swift
@@ -13,6 +13,7 @@ import Logging
 private let log = Logger(label: "BLIngestObjects")
 
 // MARK: - Public API
+@MainActor
 public func BLIngestObjects(_ objects: [NSObject], inChat chatId: String? = nil, service: IMServiceStyle) -> Promise<[ChatItem]> {
     guard objects.count > 0 else {
         *log.debug("Early-exit BLIngest because objects is empty")
@@ -58,6 +59,7 @@ public func BLIngestObjects(_ objects: [NSObject], inChat chatId: String? = nil,
     }
 }
 
+@MainActor
 public func BLIngestObject(_ object: NSObject, inChat chatId: String? = nil, service: IMServiceStyle) -> Promise<ChatItem> {
     guard let chatId else {
         return _BLResolveChatID(forObject: object)

--- a/Core/Barcelona/Wrappers/Core/Attachment.swift
+++ b/Core/Barcelona/Wrappers/Core/Attachment.swift
@@ -123,6 +123,7 @@ public struct Attachment: Codable, Hashable {
     }
     
     @discardableResult
+    @MainActor
     public func initializeFileTransferIfNeeded() -> IMFileTransfer? {
         if let transfer = existingFileTransfer {
             return transfer

--- a/Core/Barcelona/Wrappers/Core/Chat.swift
+++ b/Core/Barcelona/Wrappers/Core/Chat.swift
@@ -65,6 +65,7 @@ public struct Chat: Codable, ChatConfigurationRepresentable, Hashable {
     /// Useful for adding application-specific behavior, allows you to hook into different APIs on Chat (like sending)
     public static var delegate: ChatDelegate?
     
+    @MainActor
     public init(_ backing: IMChat) {
         joinState = backing.joinState
         roomName = backing.roomName
@@ -210,16 +211,19 @@ public extension Chat {
     }
     
     /// Returns a chat targeted at the appropriate service for a handleID
+    @MainActor
     static func directMessage(withHandleID handleID: String) -> Chat {
         Chat(IMChatRegistry.shared.chat(for: bestHandle(forID: handleID)))
     }
     
     /// Returns a chat targeted at the appropriate service for a handleID
+    @MainActor
     static func directMessage(withHandleID handleID: String, service: IMServiceStyle) -> Chat {
         Chat(IMChatRegistry.shared.chat(for: bestHandle(forID: handleID, service: service)))
     }
     
     /// Returns a chat targeted at the appropriate service for a set of handleIDs
+    @MainActor
     static func chat(withHandleIDs handleIDs: [String], service: IMServiceStyle) -> Chat {
         guard handleIDs.count > 0 else {
             preconditionFailure("chat(withHandleIDs) requires at least one handle ID to be non-null return type")
@@ -236,6 +240,7 @@ public extension Chat {
         }
     }
 
+    @MainActor
     static func firstChatRegardlessOfService(withId chatId: String) -> Chat? {
         for service in [IMServiceStyle.iMessage, IMServiceStyle.SMS] {
             if let chat = IMChat.chat(withIdentifier: chatId, onService: service, style: nil) {
@@ -258,6 +263,7 @@ public extension Thread {
 
 // MARK: - Message Sending
 public extension Chat {
+    @MainActor
     func messages(before: String? = nil, limit: Int? = nil, beforeDate: Date? = nil) -> Promise<[Message]> {
         guard let service else {
             log.warning("Cannot get messages(before: \(String(describing: before))) because service is nil; would not know what chat to check")

--- a/Core/Barcelona/Wrappers/Core/Message.swift
+++ b/Core/Barcelona/Wrappers/Core/Message.swift
@@ -470,6 +470,7 @@ public struct Message: ChatItemOwned, CustomDebugStringConvertible, Hashable {
         .message
     }
     
+    @MainActor
     public var isReadByMe: Bool {
         let log = Logger(label: "Message")
         if fromMe {

--- a/Core/Barcelona/Wrappers/Core/Messaging/MessageSending.swift
+++ b/Core/Barcelona/Wrappers/Core/Messaging/MessageSending.swift
@@ -29,6 +29,7 @@ extension Encodable {
     }
 }
 
+@MainActor
 extension IMChat {
     var log: Logging.Logger {
         Logger(label: "IMChat")
@@ -87,6 +88,7 @@ public extension Chat {
         imChat.flatMap { CBChatRegistry.shared.chats[.guid($0.guid)] }
     }
 
+    @MainActor
     func sendReturningRaw(message createMessage: CreateMessage, from: String? = nil) throws -> IMMessage {
         guard let imChat, let service else {
             throw BarcelonaError(code: 500, message: "No imChat or service to send with for \(self.id)")
@@ -118,18 +120,16 @@ public extension Chat {
         
         Chat.delegate?.chat(self, willSendMessages: [message], fromCreateMessage: createMessage)
         
-        Thread.main.sync {
-            markAsRead()
-            let imChat = imChat
-            if let from = from {
-                imChat.lastAddressedHandleID = from
-            }
-            imChat.send(message)
+        markAsRead()
+        if let from = from {
+            imChat.lastAddressedHandleID = from
         }
-        
+        imChat.send(message)
+
         return message
     }
-    
+
+    @MainActor
     func send(message createMessage: CreateMessage, from: String? = nil) throws -> Message {
         guard let imChat, let service else {
             throw BarcelonaError(code: 500, message: "No IMChat or service for \(id)")
@@ -137,7 +137,8 @@ public extension Chat {
 
         return Message(messageItem: try sendReturningRaw(message: createMessage, from: from)._imMessageItem, chatID: imChat.id, service: service)
     }
-    
+
+    @MainActor
     func tapback(_ creation: TapbackCreation, metadata: Message.Metadata? = nil) throws -> Message {
         markAsRead()
         guard let imChat, let service else {

--- a/XCSpec/beeper.yaml
+++ b/XCSpec/beeper.yaml
@@ -92,3 +92,8 @@ targets:
       - path: ../Beeper/BarcelonaMautrixIPC
         includes:
           - "**/*_Tests.swift"
+aggregateTargets:
+  periphery:
+    buildScripts:
+      - script: |
+          /opt/homebrew/bin/periphery scan --config ${SRCROOT}/.periphery.yml


### PR DESCRIPTION
Improve memory safety by enforing main thread use.

`@MainActor` should be added to most places, as there is very little reason not to block the main thread on a server. But that requires adding a lot of annotations, so this PR only includes the places that have known memory access issues.