### PR TITLE
Fix login bridge states

### DIFF
--- a/Beeper/BarcelonaMautrixIPC/Commands/Requests/BridgeStatusCommand.swift
+++ b/Beeper/BarcelonaMautrixIPC/Commands/Requests/BridgeStatusCommand.swift
@@ -143,9 +143,9 @@ private extension IMAccountController {
         // Otherwise, if there is any kind of account error, we are in bad credentials.
         } else if hasAccountError {
             return .badCredentials
-        // Otherwise, if we are probably about to register, then we are connecting.
+        // Otherwise, if we are probably about to register, then we are still unconfigured.
         } else if isProbablyAboutToRegister {
-            return .connecting
+            return .unconfigured
         // Otherwise, we don't know what state we're in, but it isn't good.
         } else {
             return .unknownError

--- a/Beeper/BarcelonaMautrixIPC/Commands/Requests/BridgeStatusCommand.swift
+++ b/Beeper/BarcelonaMautrixIPC/Commands/Requests/BridgeStatusCommand.swift
@@ -129,7 +129,7 @@ private extension IMAccountController {
         
         // True if the account failed to register, has a known registration failure reason, or most recently failed to register
         var hasAccountError: Bool {
-            account.registrationStatus == .failed || account.registrationFailureReason > .unknownError || registrationFailureDate != nil
+            account.registrationStatus == .failed || account.registrationFailureReason > .cannotConnect
         }
         
         // If we are registered but disconnected, consider that a TRANSIENT_DISCONNECT


### PR DESCRIPTION
Don't report `BAD_CREDENTIALS` or `CONNECTING` while logging in.

Bad credentials should be correctly reported after login now, but `CONNECTING` is not yet handled.

Fixes BE-7485