### PR TITLE
Re-enable Big Sur compatibility

### DIFF
--- a/Beeper/barcelona-mautrix/BarcelonaMautrix.swift
+++ b/Beeper/barcelona-mautrix/BarcelonaMautrix.swift
@@ -31,7 +31,9 @@ class BarcelonaMautrix {
     static private func configureSentry(dsn: String) {
         SentrySDK.start { options in
             options.dsn = dsn
-            options.enableMetricKit = true
+            if #available(macOS 12.0, *) {
+                options.enableMetricKit = true
+            }
             options.sendDefaultPii = true
             options.enableAppHangTracking = false
             options.enableAutoSessionTracking = false

--- a/Core/Barcelona/Extensions/Glue/Publishers.swift
+++ b/Core/Barcelona/Extensions/Glue/Publishers.swift
@@ -9,18 +9,6 @@ import Foundation
 import Combine
 
 extension Publisher {
-    func toFuture() -> Future<Output, Failure> {
-        return Future<Output, Failure> { resolve in
-            self.retainingSink {
-                if case let .failure(error) = $0 {
-                    resolve(.failure(error))
-                }
-            } receiveValue: {
-                resolve(.success($0))
-            }
-        }
-    }
-
     @discardableResult
     func retainingSink(receiveCompletion: @escaping (Subscribers.Completion<Failure>) -> Void, receiveValue: @escaping (Output) -> Void) -> AnyCancellable? {
         var cancellable: AnyCancellable?

--- a/Core/Barcelona/Queries/IMDPersistenceMarshal.swift
+++ b/Core/Barcelona/Queries/IMDPersistenceMarshal.swift
@@ -6,24 +6,25 @@
 //  Copyright © 2021 Eric Rabil. All rights reserved.
 //
 
-import Foundation
 import Combine
+import Foundation
 
-private extension Dictionary {
-    func merge(into dictionary: inout Dictionary) {
+extension Dictionary {
+    fileprivate func merge(into dictionary: inout Dictionary) {
         forEach {
             dictionary[$0.key] = $0.value
         }
     }
 }
 
-private extension Collection where Element: Hashable {
-    func intersects<SomeCollection: Collection>(collection: SomeCollection) -> Bool where SomeCollection.Element == Element {
+extension Collection where Element: Hashable {
+    fileprivate func intersects<SomeCollection: Collection>(collection: SomeCollection) -> Bool
+    where SomeCollection.Element == Element {
         collection.first(where: contains) != nil
     }
 }
 
-internal extension OperationBuffer {
+extension OperationBuffer {
     @_transparent
     @usableFromInline
     func performLocked<P>(_ cb: () throws -> P) rethrows -> P {
@@ -35,81 +36,77 @@ internal extension OperationBuffer {
 
 public class OperationBuffer<Output, Discriminator: Hashable> {
     @usableFromInline
-    typealias RawBuffer = Future<[Output], Never>
-    
+    typealias RawBuffer = Task<[Output], Never>
+
     @usableFromInline
-    typealias LazyBuffer = Future<[Discriminator: Output], Never>
-    
+    typealias LazyBuffer = Task<[Discriminator: Output], Never>
+
     @usableFromInline
     internal var rawBuffers = [[Discriminator]: RawBuffer]()
     private var lazyBuffers = [[Discriminator]: LazyBuffer]()
-    
+
     private var discriminatorKeyPath: KeyPath<Output, Discriminator>
     @usableFromInline
     internal var lock = NSRecursiveLock()
-    
+
     public init(discriminatorKeyPath: KeyPath<Output, Discriminator>) {
         self.discriminatorKeyPath = discriminatorKeyPath
     }
-    
+
     private func lazyBuffer(_ ids: [Discriminator]) -> LazyBuffer? {
         if let lazyBuffer = lazyBuffers[ids] {
             return lazyBuffer
         }
-        
+
         guard let rawBuffer = rawBuffers[ids] else {
             return nil
         }
 
-        let lazyBuffer = rawBuffer.map {
-            $0.dictionary(keyedBy: self.discriminatorKeyPath)
-        }.toFuture()
-        
+        let lazyBuffer = Task {
+            await rawBuffer.value.dictionary(keyedBy: self.discriminatorKeyPath)
+        }
+
         self.performLocked {
-            self.lazyBuffers[ids] = Future<[Discriminator: Output], Never> { resolve in
-                Task {
-                    let values = await lazyBuffer.value
-                    self.performLocked {
-                        _ = self.lazyBuffers.removeValue(forKey: ids)
-                    }
-                    resolve(.success(values))
+            self.lazyBuffers[ids] = Task<[Discriminator: Output], Never> {
+                let values = await lazyBuffer.value
+                self.performLocked {
+                    _ = self.lazyBuffers.removeValue(forKey: ids)
                 }
+                return values
             }
         }
-        
+
         return lazyBuffer
     }
-    
-    private func directBuffer(_ ids: [Discriminator]) -> Future<[Output], Never>? {
+
+    private func directBuffer(_ ids: [Discriminator]) -> Task<[Output], Never>? {
         rawBuffers[ids]
     }
-    
+
     @inlinable
-    func putBuffers(_ ids: [Discriminator], _ pending: Future<[Output], Never>) {
+    func putBuffers(_ ids: [Discriminator], _ pending: Task<[Output], Never>) {
         performLocked {
-            rawBuffers[ids] = Future<[Output], Never> { resolve in
-                Task {
-                    let values = await pending.value
-                    _ = self.performLocked {
-                        self.rawBuffers.removeValue(forKey: ids)
-                    }
-                    resolve(.success(values))
+            rawBuffers[ids] = Task<[Output], Never> {
+                let values = await pending.value
+                _ = self.performLocked {
+                    self.rawBuffers.removeValue(forKey: ids)
                 }
+                return values
             }
         }
     }
-    
+
     @usableFromInline
-    func partialBuffer(_ ids: [Discriminator]) -> (Future<[Output], Never>, remaining: [Discriminator]?) {
+    func partialBuffer(_ ids: [Discriminator]) -> (Task<[Output], Never>, remaining: [Discriminator]?) {
         if let directBuffer = directBuffer(ids) {
             return (directBuffer, nil)
         }
-        
+
         /// aggregate all keys that point to pending results for these ids
         let keys = rawBuffers.keys.filter {
             $0.intersects(collection: ids)
         }
-        
+
         var matched = Set<Discriminator>()
         // computes all ids that have not yet been matched
         var needed: [Discriminator] {
@@ -118,56 +115,54 @@ public class OperationBuffer<Output, Discriminator: Hashable> {
             }
         }
         var using = [LazyBuffer]()
-        
+
         for key in keys {
             let needed = needed
             let matches = key.filter {
                 needed.contains($0)
             }
-            
+
             guard matches.count > 0 else {
                 // key did match, but has been superseded by a previous key
                 continue
             }
-            
+
             matches.forEach {
                 matched.insert($0)
             }
-            
+
             // add the buffer to the chunk we're going to merge
             guard let lazyBuffer = lazyBuffer(key) else {
                 continue
             }
-            
+
             using.append(lazyBuffer)
         }
-        
+
+        // We need this to access the captured var `using` in concurrent code
+        let getValues: () async -> [Discriminator: Output] = {
+            var values = [Discriminator: Output]()
+            // Get all the values from the buffers that we're trying to use
+            for fut in using {
+                let newVals = await fut.value
+                for val in newVals {
+                    values[val.key] = val.value
+                }
+            }
+
+            return values
+        }
+
         return (
-            Future<[Output], Never> { resolve in
-                // We need this to access the captured var `using` in concurrent code
-                let getValues: () async -> [Discriminator: Output] = {
-                    var values = [Discriminator: Output]()
-                    // Get all the values from the buffers that we're trying to use
-                    for fut in using {
-                        let newVals = await fut.value
-                        for val in newVals {
-                            values[val.key] = val.value
-                        }
+            Task<[Output], Never> {  // resolve in
+                let resolved = await getValues()
+                    .dictionary(keyedBy: \.key, valuedBy: \.value)
+                    .filter {
+                        ids.contains($0.key)
                     }
+                    .map(\.value)
 
-                    return values
-                }
-
-                Task {
-                    let resolved = await getValues()
-                        .dictionary(keyedBy: \.key, valuedBy: \.value)
-                        .filter {
-                            ids.contains($0.key)
-                        }
-                        .map(\.value)
-
-                    resolve(.success(resolved))
-                }
+                return resolved
             },
             remaining: needed.count == 0 ? nil : needed
         )

--- a/XCSpec/beeper.yaml
+++ b/XCSpec/beeper.yaml
@@ -38,7 +38,6 @@ targets:
         PRODUCT_NAME: barcelona-mautrix-${platform}
         PRODUCT_MODULE_NAME: barcelona_mautrix
         CREATE_INFOPLIST_SECTION_IN_BINARY: YES
-        MACOSX_DEPLOYMENT_TARGET: "13.0"
     info:
       path: ../Beeper/barcelona-mautrix/Info.plist
       properties:

--- a/XCSpec/templates.yaml
+++ b/XCSpec/templates.yaml
@@ -10,7 +10,6 @@ targetTemplates:
         PRODUCT_NAME: "$(TARGET_NAME:c99extidentifier)"
         VALID_ARCHS: "x86_64 arm64e arm64"
         SUPPORTED_PLATFORMS: "macosx iphonesimulator iphoneos"
-        MACOSX_DEPLOYMENT_TARGET: "13.0"
   BLTest:
     type: bundle.unit-test
     platform: macOS
@@ -19,11 +18,10 @@ targetTemplates:
         SWIFT_ACTIVE_COMPILATION_CONDITIONS: $(inherited) UNIT_TEST
         TEST_HOST: $(BUILT_PRODUCTS_DIR)/${test_host}.app/Contents/MacOS/${test_host}
         BUNDLE_LOADER: $(TEST_HOST)
-        MACOSX_DEPLOYMENT_TARGET: "13.0"
     postBuildScripts:
       - name: Codesign
         script: |
-          codesign -f -s "$CODE_SIGN_IDENTITY" --deep $BUILT_PRODUCTS_DIR/${test_host}.app/Contents/PlugIns/${target_name}.xctest
+            codesign -f -s "$CODE_SIGN_IDENTITY" --deep $BUILT_PRODUCTS_DIR/${test_host}.app/Contents/PlugIns/${target_name}.xctest
     dependencies:
       - target: ${test_host}
   BLTestHost:
@@ -37,6 +35,5 @@ targetTemplates:
       - ../Beeper/BarcelonaTestHost
     settings:
       CODE_SIGN_ENTITLEMENTS: ${entitlements}
-      MACOSX_DEPLOYMENT_TARGET: "13.0"
     dependencies:
       - package: XCTHarness


### PR DESCRIPTION
Remove all the use of macOS 12 and above APIs.

I replaced `Future`s with `Task` to keep the API roughly the same. Not sure how many of those are needed anymore, but I wanted a safer diff and they can be refactored once this has been confirmed to work.

Sorry for the ugly diff again; I'm too careless with `swift-format`...