### PR TITLE
Fix various issues I noticed while debugging

### DIFF
--- a/Beeper/BarcelonaMautrixIPC/IPCHandlers/BLHandlePayload.swift
+++ b/Beeper/BarcelonaMautrixIPC/IPCHandlers/BLHandlePayload.swift
@@ -58,7 +58,7 @@ func BLHandlePayload(_ payload: IPCPayload, ipcChannel: MautrixIPCChannel) {
         }
     }
 
-    DispatchQueue.main.async {
-        runnable.run(payload: payload, ipcChannel: ipcChannel)
+    Task { @MainActor in
+        await runnable.run(payload: payload, ipcChannel: ipcChannel)
     }
 }

--- a/Beeper/BarcelonaMautrixIPC/IPCHandlers/CommandHandlers/SendMediaMessageCommand+Handler.swift
+++ b/Beeper/BarcelonaMautrixIPC/IPCHandlers/CommandHandlers/SendMediaMessageCommand+Handler.swift
@@ -13,7 +13,7 @@ import Sentry
 import Logging
 
 protocol Runnable {
-    func run(payload: IPCPayload, ipcChannel: MautrixIPCChannel)
+    func run(payload: IPCPayload, ipcChannel: MautrixIPCChannel) async
 }
 
 protocol AuthenticatedAsserting {}
@@ -22,7 +22,7 @@ extension SendMediaMessageCommand: Runnable, AuthenticatedAsserting {
     var log: Logging.Logger {
         Logger(label: "SendMediaMessageCommand")
     }
-    public func run(payload: IPCPayload, ipcChannel: MautrixIPCChannel) {
+    public func run(payload: IPCPayload, ipcChannel: MautrixIPCChannel) async {
         guard let chat = cbChat, let imChat = chat.imChat else {
             return payload.fail(strategy: .chat_not_found, ipcChannel: ipcChannel)
         }

--- a/Beeper/BarcelonaMautrixIPC/IPCHandlers/CommandHandlers/SendMessageCommand+Handler.swift
+++ b/Beeper/BarcelonaMautrixIPC/IPCHandlers/CommandHandlers/SendMessageCommand+Handler.swift
@@ -14,7 +14,7 @@ import Logging
 private let log = Logger(label: "SendMessageCommand")
 
 extension SendMessageCommand: Runnable, AuthenticatedAsserting {
-    public func run(payload: IPCPayload, ipcChannel: MautrixIPCChannel) {
+    public func run(payload: IPCPayload, ipcChannel: MautrixIPCChannel) async {
         guard let chat = cbChat, let imChat = chat.imChat else {
             return payload.fail(strategy: .chat_not_found, ipcChannel: ipcChannel)
         }

--- a/Beeper/BarcelonaMautrixIPC/IPCHandlers/CommandHandlers/SendTapbackCommand+Handler.swift
+++ b/Beeper/BarcelonaMautrixIPC/IPCHandlers/CommandHandlers/SendTapbackCommand+Handler.swift
@@ -14,7 +14,8 @@ extension TapbackCommand: Runnable, AuthenticatedAsserting {
     var log: Logging.Logger {
         Logger(label: "TapbackCommand")
     }
-    public func run(payload: IPCPayload, ipcChannel: MautrixIPCChannel) {
+    
+    public func run(payload: IPCPayload, ipcChannel: MautrixIPCChannel) async {
         guard let chat = cbChat else {
             return payload.fail(strategy: .chat_not_found, ipcChannel: ipcChannel)
         }

--- a/Beeper/BarcelonaMautrixIPC/Runtime/UnixSocketMautrixIPCChannel.swift
+++ b/Beeper/BarcelonaMautrixIPC/Runtime/UnixSocketMautrixIPCChannel.swift
@@ -23,7 +23,7 @@ public class UnixSocketMautrixIPCChannel: MautrixIPCInputChannel, MautrixIPCOutp
 
     public func listen(_ cb: @escaping (Data) -> Void) {
         do {
-            let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+            let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
             let client = ClientBootstrap(group: group)
             channel = try client.channelInitializer { channel in
                 channel.pipeline.addHandler(ClosureReadHandler(readCallback: cb))

--- a/Core/Barcelona/CoreBarcelona/CBDaemonListener.swift
+++ b/Core/Barcelona/CoreBarcelona/CBDaemonListener.swift
@@ -218,8 +218,20 @@ internal extension CBDaemonListener {
             self.chatConfigurationPipeline.send(chat.configurationBits)
         }
 
-        NotificationCenter.default.addObserver(forName: .init("__kIMPeopleAddedNotification"), object: nil, queue: nil) { notification in
-            log.debug("People were added: \(notification.object.debugDescription)")
+        NotificationCenter.default.addObserver(forName: .IMPeopleAdded, object: nil, queue: nil) { notification in
+            log.debug("IMPeopleAdded: \(notification.object), \(notification.userInfo)")
+        }
+
+        NotificationCenter.default.addObserver(forName: .IMChatRegistryDidRegisterChat, object: nil, queue: nil) { notification in
+            log.debug("IMChatRegistryDidRegisterChat: \(notification.object), \(notification.userInfo)")
+        }
+
+        NotificationCenter.default.addObserver(forName: .IMHandleStatusChanged, object: nil, queue: nil) { notification in
+            log.debug("IMHandleStatusChanged: \(notification.object), \(notification.userInfo)")
+        }
+
+        NotificationCenter.default.addObserver(forName: .IMChatParticipantsDidChange, object: nil, queue: nil) { notification in
+            log.debug("IMChatParticipantsDidChange: \(notification.object), \(notification.userInfo)")
         }
 
         ifDebugBuild {
@@ -461,7 +473,7 @@ public class CBDaemonListener: ERBaseDaemonListener {
     
     // Properties were changed
     public override func chat(_ persistentIdentifier: String, updated updateDictionary: [AnyHashable : Any]) {
-        log.debug("chat:\(persistentIdentifier) updated:\(updateDictionary)")
+        log.debug("chat:\(persistentIdentifier) updated:\(updateDictionary.singleLineDebugDescription)")
         apply(serializedChat: updateDictionary, emitIfNeeded: true)
     }
     

--- a/Core/Barcelona/CoreBarcelona/Paris/CBChatLeaf.swift
+++ b/Core/Barcelona/CoreBarcelona/Paris/CBChatLeaf.swift
@@ -77,12 +77,7 @@ public struct CBChatLeaf {
         originalGroupID = dictionary["originalGroupID"] as? String ?? originalGroupID
         if let participants = dictionary["participants"] as? [[AnyHashable: Any]] {
             self.participants = participants.compactMap(CBChatParticipant.init(dictionary:))
-            if (dictionary["style"] as? UInt8) == 45, self.participants.count == 1 {
-                let uri = (self.participants[0].personID as NSString)._bestGuessURIFromCanicalizedID() as! String
-                correlationID = CBSenderCorrelationController.shared.correlate(sameSenders: [uri], offline: true, hitDatabase: false) ?? ""
-            } else {
-                correlationID = ""
-            }
+            correlationID = ""
         }
         return self
     }

--- a/Core/Barcelona/CoreBarcelona/Paris/CBChatRegistry.swift
+++ b/Core/Barcelona/CoreBarcelona/Paris/CBChatRegistry.swift
@@ -41,15 +41,15 @@ public class CBChatRegistry: NSObject, IMDaemonListenerProtocol {
     }
     
     public func chat(_ persistentIdentifier: String!, updated updateDictionary: [AnyHashable : Any]!) {
-        trace(nil, nil, "persistentIdentifier \(persistentIdentifier!) updated \(updateDictionary)")
+        trace(nil, nil, "persistentIdentifier \(persistentIdentifier!) updated \(updateDictionary.singleLineDebugDescription)")
         _ = handle(chat: updateDictionary)
     }
     
     public func chat(_ persistentIdentifier: String!, propertiesUpdated properties: [AnyHashable : Any]!) {
-        trace(nil, nil, "persistentIdentifier \(persistentIdentifier!) properties \(properties)")
+        trace(nil, nil, "persistentIdentifier \(persistentIdentifier!) properties \(properties.singleLineDebugDescription)")
         _ = handle(chat: [
-            "guid": persistentIdentifier,
-            "properties": properties
+            "guid": persistentIdentifier as Any,
+            "properties": properties as Any
         ])
     }
     
@@ -79,11 +79,7 @@ public class CBChatRegistry: NSObject, IMDaemonListenerProtocol {
     }
     
     public func service(_ serviceID: String!, chat chatIdentifier: String!, style chatStyle: IMChatStyle, messagesUpdated messages: [[AnyHashable: Any]]!) {
-        #if DEBUG
-        trace(chatIdentifier, nil, "messages updated \(messages.debugDescription)")
-        #else
-        trace(chatIdentifier, nil, "\(messages.count) messages updated in")
-        #endif
+        trace(chatIdentifier, nil, "messages updated \(messages)")
         messages.forEach {
             handle(chat: .chatIdentifier(chatIdentifier), item: $0)
         }

--- a/Core/Barcelona/Extensions/Foundation/String+FastDropURI.swift
+++ b/Core/Barcelona/Extensions/Foundation/String+FastDropURI.swift
@@ -18,3 +18,9 @@ extension String {
         return String(self[self.index(after: index)...])
     }
 }
+
+extension CustomDebugStringConvertible {
+    var singleLineDebugDescription: String {
+        debugDescription.replacingOccurrences(of: "\n", with: " ")
+    }
+}

--- a/Core/Barcelona/IMCoreHelpers/BarcelonaManager.swift
+++ b/Core/Barcelona/IMCoreHelpers/BarcelonaManager.swift
@@ -135,8 +135,12 @@ public func BLBootstrapController(_ callbackC: (@convention(c) (Bool) -> ())? = 
         #if DEBUG
         log.debug("Set up IMContactStore. Loading correlation controller...")
         #endif
-        
-        _ = CBSenderCorrelationController.shared
+
+        // CBSenderCorrelationController's usage of Pwomise creates data races (according to the thread sanitizer)
+        // and we don't use it anymore, so let's just make sure it's never called so that we don't get those data races.
+        // Also, once I commented this out, I was able to debug async functions (whereas previously breakpoints in some
+        // top-level async functions would never catch, but if we never call the controller, they do catch)
+        // _ = CBSenderCorrelationController.shared
         
         #if DEBUG
         log.debug("Loaded correlation controller. Loading all chats...")

--- a/Core/Barcelona/Queries/IMDPersistence.swift
+++ b/Core/Barcelona/Queries/IMDPersistence.swift
@@ -156,7 +156,7 @@ private func BLCreateIMMessageFromIMDMessageRecordRefs(_ refs: NSArray) -> [IMMe
 /// - Parameters:
 ///   - refs: the refs to parse
 ///   - chat: the ID of the chat the messages reside in. if omitted, the chat ID will be resolved at ingestion
-/// - Returns: An NIO future of ChatItems
+/// - Returns: The `ChatItem`s representing the ingested refs
 private func BLIngestIMDMessageRecordRefs(
     _ refs: NSArray,
     in chat: String? = nil,
@@ -235,7 +235,7 @@ public func BLLoadIMMessage(withGUID guid: String) -> IMMessage? {
 /// - Parameters:
 ///   - guids: GUIDs of messages to load
 ///   - chat: ID of the chat to load. if omitted, it will be resolved at ingestion.
-/// - Returns: NIO future of ChatItems
+/// - Returns: The requested `ChatItem`s
 public func BLLoadChatItems(
     withGUIDs guids: [String],
     chatID: String? = nil,
@@ -254,11 +254,7 @@ public func BLLoadChatItems(
     let refs = BLLoadIMDMessageRecordRefsWithGUIDs(guids)
 
     let ingestFut = Task<[ChatItem], Never> {
-        do {
-            return try await BLIngestIMDMessageRecordRefs(refs, in: chatID, service: service)
-        } catch {
-            return []
-        }
+        (try? await BLIngestIMDMessageRecordRefs(refs, in: chatID, service: service)) ?? []
     }
 
     IMDPersistenceMarshal.putBuffers(guids, ingestFut)
@@ -310,7 +306,7 @@ public func BLLoadChatItems(withGraph graph: [String: ([String], IMServiceStyle)
 ///   - services: chat services to load messages from
 ///   - beforeGUID: GUID of the message all messages must precede
 ///   - limit: max number of messages to return
-/// - Returns: NIO future of ChatItems
+/// - Returns: The requested `ChatItem`s
 public func BLLoadChatItems(
     withChats chats: [(id: String, service: IMServiceStyle)],
     afterDate: Date? = nil,


### PR DESCRIPTION
- Move IPCCommands to async functions (so we don't have to spawn `Task`s within them, which could possibly cause race conditions if some requests take longer than others)
- Add more notifications to detect people being added/handles registering (for 7470)
- Print dictionaries in a single line so they are processed more prettily in logs due to mautrix logs being line-buffered from barcelona stdout
- Don't call `CBSenderCorrelationController.shared` since we don't want to use it and pwomise is creating data races inside it (also, once I stopped calling this method and thus `CBSenderCorrelationController` was never init'ed, it fixed some issues with async functions. Before commenting this out, breakpoints inside `BLLoadChatItems` wouldn't catch, even though the function was clearly being called, but after commenting them out, they all caught nicely and everything played well. Further evidence we should move to async/await instead of pwomise)
- Make some doc comment return types more accurate
- Make NIO only use two threads (every time I pause execution all NIO threads are completely inert, I think we definitely don't need to spawn 1 for each core).