### PR TITLE
Fix crash from sending on wrong thread

### DIFF
--- a/Beeper/BarcelonaMautrixIPC/IPCHandlers/CommandHandlers/SendMediaMessageCommand+Handler.swift
+++ b/Beeper/BarcelonaMautrixIPC/IPCHandlers/CommandHandlers/SendMediaMessageCommand+Handler.swift
@@ -93,7 +93,7 @@ extension SendMediaMessageCommand: Runnable, AuthenticatedAsserting {
                 withExtendedLifetime(monitor) { monitor = nil }
             }
 
-            message = try chat.sendReturningRaw(message: messageCreation)
+            message = try await chat.sendReturningRaw(message: messageCreation)
 
             payload.reply(
                 withResponse: .message_receipt(

--- a/Beeper/BarcelonaMautrixIPC/IPCHandlers/CommandHandlers/SendMessageCommand+Handler.swift
+++ b/Beeper/BarcelonaMautrixIPC/IPCHandlers/CommandHandlers/SendMessageCommand+Handler.swift
@@ -97,7 +97,7 @@ extension SendMessageCommand: Runnable, AuthenticatedAsserting {
                 messageCreation.replyToPart = reply_to_part
                 messageCreation.metadata = metadata
 
-                finalMessage = try chat.send(message: messageCreation)
+                finalMessage = try await chat.send(message: messageCreation)
             }
 
             payload.reply(

--- a/Core/Barcelona/CoreBarcelona/Paris/CBChat.swift
+++ b/Core/Barcelona/CoreBarcelona/Paris/CBChat.swift
@@ -237,15 +237,16 @@ extension IMHandle {
 
 // MARK: - Message sending
 extension CBChat {
+    @MainActor
     public func send(message: IMMessage, chat: IMChat) {
         chat.send(message)
     }
 
-    public func send(message: IMMessageItem, chat: IMChat) {
-        send(message: IMMessage(fromIMMessageItem: message, sender: nil, subject: nil), chat: chat)
+    public func send(message: IMMessageItem, chat: IMChat) async {
+        await send(message: IMMessage(fromIMMessageItem: message, sender: nil, subject: nil), chat: chat)
     }
 
-    public func send(message: CreateMessage, guid: String, service: IMServiceStyle) throws -> IMMessage {
+    public func send(message: CreateMessage, guid: String, service: IMServiceStyle) async throws -> IMMessage {
         guard let chat = chatForSending(with: guid) else {
             throw BarcelonaError(
                 code: 400,
@@ -254,7 +255,7 @@ extension CBChat {
             )
         }
         let message = try message.imMessage(inChat: chat.chatIdentifier, service: service)
-        send(message: message, chat: chat)
+        await send(message: message, chat: chat)
         return message
     }
 }

--- a/Core/Barcelona/CoreBarcelona/Paris/CBMessage.swift
+++ b/Core/Barcelona/CoreBarcelona/Paris/CBMessage.swift
@@ -482,6 +482,8 @@ extension CBMessage {
             return
         }
         log.info("Re-sending message \(id) on chat \(String(describing: imChat.guid))")
-        chat.send(message: message, chat: imChat)
+        Task {
+            await chat.send(message: message, chat: imChat)
+        }
     }
 }

--- a/Core/Barcelona/Extensions/Fun/Chat+@everyone.swift
+++ b/Core/Barcelona/Extensions/Fun/Chat+@everyone.swift
@@ -18,7 +18,7 @@ extension Chat {
         case textTooShort
     }
 
-    public func pingEveryone(text: String) throws -> Message {
+    public func pingEveryone(text: String) async throws -> Message {
         let targetParticipants = participants.filter {
             !$0.cb_isOneOfMyHandles
         }
@@ -36,6 +36,6 @@ extension Chat {
                 )
             }
         }
-        return try send(message: .init(parts: parts))
+        return try await send(message: .init(parts: parts))
     }
 }

--- a/Core/Barcelona/Wrappers/Core/Messaging/MessageSending.swift
+++ b/Core/Barcelona/Wrappers/Core/Messaging/MessageSending.swift
@@ -92,7 +92,7 @@ extension Chat {
         imChat.flatMap { CBChatRegistry.shared.chats[.guid($0.guid)] }
     }
 
-    public func sendReturningRaw(message createMessage: CreateMessage, from: String? = nil) throws -> IMMessage {
+    public func sendReturningRaw(message createMessage: CreateMessage, from: String? = nil) async throws -> IMMessage {
         guard let imChat, let service else {
             throw BarcelonaError(code: 500, message: "No imChat or service to send with for \(self.id)")
         }
@@ -127,7 +127,7 @@ extension Chat {
             }
 
             log.info("Using CBChat for sending per feature flags", source: "MessageSending")
-            return try cbChat.send(message: createMessage, guid: imChat.guid, service: service)
+            return try await cbChat.send(message: createMessage, guid: imChat.guid, service: service)
         }
 
         imChat.refreshServiceForSendingIfNeeded()
@@ -148,13 +148,13 @@ extension Chat {
         return message
     }
 
-    public func send(message createMessage: CreateMessage, from: String? = nil) throws -> Message {
+    public func send(message createMessage: CreateMessage, from: String? = nil) async throws -> Message {
         guard let imChat, let service else {
             throw BarcelonaError(code: 500, message: "No IMChat or service for \(id)")
         }
 
         return Message(
-            messageItem: try sendReturningRaw(message: createMessage, from: from)._imMessageItem,
+            messageItem: try await sendReturningRaw(message: createMessage, from: from)._imMessageItem,
             chatID: imChat.id,
             service: service
         )


### PR DESCRIPTION
Sending messages currently causes a crash. Enforce proper thread with `@MainActor`.
```
Exception Type: EXC_BAD_INSTRUCTION (SIGILL)
Exception Codes: ILL_NOOP at 0x00007ff81693d51a
Crashed Thread: 3

Application Specific Information:
BUG IN CLIENT OF LIBDISPATCH: Assertion failed: Block was expected to execute on queue [com.apple.main-thread (0x7ff85a0fc640)]

Thread 3 Crashed:
0   libdispatch.dylib               0xfff016b8651a      _dispatch_assert_queue_fail
1   libdispatch.dylib               0xfff016b864b3      dispatch_assert_queue
2   IMCore                          0xfff235eb9c23      _IMStringFromIMChatJoinState
3   barcelona-mautrix               0x20055446c         -[IMChat(HistoryLoadingPatch) _ghetto_updateChatItemsWithReason:block:shouldPost:] (IMCore-Shims.m:47)
4   IMCore                          0xfff235ea3c19      IMPersonStatusFromFZPersonStatus
5   IMCore                          0xfff235ea6838      IMPersonStatusFromFZPersonStatus
6   barcelona-mautrix               0x2006bda25         [inlined] CBChat.send (CBChat.swift:241)
7   barcelona-mautrix               0x2006bda25         [inlined] CBChat.send (CBChat.swift:257)
8   barcelona-mautrix               0x2006bda25         Chat.sendReturningRaw (MessageSending.swift:130)
9   barcelona-mautrix               0x2006bbc16         Chat.send (MessageSending.swift:157)
10  barcelona-mautrix               0x2008e1772         SendMessageCommand.run (SendMessageCommand+Handler.swift:100)
11  libswift_Concurrency.dylib      0xfff64dc2c556      swift::runJobInEstablishedExecutorContext
```