### PR TITLE
Fix more various issues

### DIFF
--- a/Beeper/barcelona-mautrix/barcelona-mautrix.entitlements
+++ b/Beeper/barcelona-mautrix/barcelona-mautrix.entitlements
@@ -81,6 +81,7 @@
 	<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
 	<array>
 		<string>com.apple.accountsd.accountmanager</string>
+		<string>com.apple.imdpersistence.IMDPersistenceAgent</string>
 		<string>com.apple.dmd.policy</string>
 		<string>com.apple.dmd.emergency-mode</string>
 		<string>com.apple.marco</string>

--- a/Core/Barcelona/Constants.swift
+++ b/Core/Barcelona/Constants.swift
@@ -28,5 +28,3 @@ public let ERChatMessageUpdatedNotification = NSNotification.Name(rawValue: "ERC
 public let ERChatMessagesDeletedNotification = NSNotification.Name(rawValue: "ERChatMessagesDeletedNotification")
 
 public let ERDefaultMessageQueryLimit: Int = 75
-
-public let BLMessageStatusChangedNotification = NSNotification.Name(rawValue: "BLMessageStatusChangedNotification")

--- a/Core/Barcelona/CoreBarcelona/CBDaemonListener.swift
+++ b/Core/Barcelona/CoreBarcelona/CBDaemonListener.swift
@@ -554,11 +554,7 @@ public class CBDaemonListener: ERBaseDaemonListener {
         chatPersonCentricID personCentricID: String!,
         messageSent msg: IMMessageItem
     ) {
-        #if DEBUG
-        log.debug("messageSent: \(msg.debugDescription)")
-        #else
-        log.debug("messageSent: \(msg.id)")
-        #endif
+        log.debug("messageSent: \(msg.singleLineDebugDescription)")
         chatIdentifierCache[msg.id] = chatIdentifier
         process(newMessage: msg, chatIdentifier: chatIdentifier)
     }
@@ -572,11 +568,7 @@ public class CBDaemonListener: ERBaseDaemonListener {
         notifySentMessage msg: IMMessageItem!,
         sendTime: NSNumber!
     ) {
-        #if DEBUG
-        log.debug("notifySentMessage: \(msg.debugDescription)")
-        #else
-        log.debug("notifySentMessage: \(msg.id)")
-        #endif
+        log.debug("notifySentMessage: \(msg.singleLineDebugDescription)")
         process(sentMessage: msg, sentTime: (msg.clientSendTime ?? msg.time ?? Date()).timeIntervalSince1970)
     }
 
@@ -589,11 +581,7 @@ public class CBDaemonListener: ERBaseDaemonListener {
         chatPersonCentricID personCentricID: String,
         messageReceived msg: IMItem
     ) {
-        #if DEBUG
-        log.debug("messageReceived: \(msg.debugDescription)")
-        #else
-        log.debug("messageReceived: \(msg.id)")
-        #endif
+        log.debug("messageReceived: \(msg.singleLineDebugDescription)")
 
         process(newMessage: msg, chatIdentifier: chatIdentifier)
     }
@@ -608,11 +596,7 @@ public class CBDaemonListener: ERBaseDaemonListener {
         messagesReceived messages: [IMItem],
         messagesComingFromStorage fromStorage: Bool
     ) {
-        #if DEBUG
-        log.debug("messagesReceived: \(messages.debugDescription)")
-        #else
-        log.debug("messagesReceived in \(chatIdentifier): \(messages.count) messages")
-        #endif
+        log.debug("messagesReceived: \(messages.singleLineDebugDescription)")
 
         for message in messages {
             process(newMessage: message, chatIdentifier: chatIdentifier)
@@ -628,11 +612,7 @@ public class CBDaemonListener: ERBaseDaemonListener {
         chatPersonCentricID personCentricID: String!,
         messagesReceived messages: [IMItem]!
     ) {
-        #if DEBUG
-        log.debug("messagesReceived: \(messages.debugDescription)")
-        #else
-        log.debug("messagesReceived in \(chatIdentifier): \(messages.count) messages")
-        #endif
+        log.debug("messagesReceived: \(messages.singleLineDebugDescription)")
 
         for message in messages {
             process(newMessage: message, chatIdentifier: chatIdentifier)
@@ -646,11 +626,7 @@ public class CBDaemonListener: ERBaseDaemonListener {
         style chatStyle: IMChatStyle,
         messagesUpdated messages: [[AnyHashable: Any]]!
     ) {
-        #if DEBUG
-        log.debug("messagesUpdated[service]: \(messages.debugDescription)")
-        #else
-        log.debug("messagesUpdated[service] in \(chatIdentifier): \(messages.count) messages")
-        #endif
+        log.debug("messagesUpdated[service]: \(messages.debugDescription.singleLineDebugDescription)")
 
         for message in CBCreateItemsFromSerializedArray(messages) {
             switch message {
@@ -685,11 +661,7 @@ public class CBDaemonListener: ERBaseDaemonListener {
         chatProperties properties: [AnyHashable: Any]!,
         messagesUpdated messages: [NSObject]!
     ) {
-        #if DEBUG
-        log.debug("messagesUpdated[account]: \(messages.debugDescription)")
-        #else
-        log.debug("messagesUpdated[account] in \(chatIdentifier): \(messages.count) messages")
-        #endif
+        log.debug("messagesUpdated[account]: \(messages.debugDescription.singleLineDebugDescription)")
 
         for message in messages as? [IMItem] ?? CBCreateItemsFromSerializedArray(messages) {
             switch message {

--- a/Core/Barcelona/CoreBarcelona/Paris/CBChatRegistry.swift
+++ b/Core/Barcelona/CoreBarcelona/Paris/CBChatRegistry.swift
@@ -93,7 +93,7 @@ public class CBChatRegistry: NSObject, IMDaemonListenerProtocol {
         style chatStyle: IMChatStyle,
         messagesUpdated messages: [[AnyHashable: Any]]!
     ) {
-        trace(chatIdentifier, nil, "messages updated \(messages)")
+        trace(chatIdentifier, nil, "messages updated \(messages.singleLineDebugDescription)")
         messages.forEach {
             handle(chat: .chatIdentifier(chatIdentifier), item: $0)
         }
@@ -117,11 +117,7 @@ public class CBChatRegistry: NSObject, IMDaemonListenerProtocol {
         notifySentMessage msg: IMMessageItem!,
         sendTime: NSNumber!
     ) {
-        #if DEBUG
-        trace(chatIdentifier, nil, "sent message \(msg.guid ?? "nil") \(msg.debugDescription)")
-        #else
-        trace(chatIdentifier, nil, "sent message \(msg.guid ?? "nil")")
-        #endif
+        trace(chatIdentifier, nil, "sent message \(msg.guid ?? "nil") \(msg.singleLineDebugDescription)")
         handle(chatIdentifier: chatIdentifier, properties: properties, groupID: nil, item: msg)
     }
 
@@ -189,11 +185,7 @@ public class CBChatRegistry: NSObject, IMDaemonListenerProtocol {
         chatPersonCentricID personCentricID: String!,
         messageReceived msg: IMItem!
     ) {
-        #if DEBUG
-        trace(chatIdentifier, personCentricID, "received message \(msg.debugDescription)")
-        #else
-        trace(chatIdentifier, personCentricID, "received message \(msg.id)")
-        #endif
+        trace(chatIdentifier, personCentricID, "received message \(msg.singleLineDebugDescription)")
         handle(chatIdentifier: chatIdentifier, properties: properties, groupID: groupID, item: msg)
     }
 
@@ -283,7 +275,7 @@ public class CBChatRegistry: NSObject, IMDaemonListenerProtocol {
         trace(
             chatIdentifier,
             nil,
-            "properties \(((properties ?? [:]) as NSDictionary)) updated to \(((update ?? [:]) as NSDictionary))"
+            "properties \(((properties ?? [:]) as NSDictionary)) updated to \(((update ?? [:]) as NSDictionary).singleLineDebugDescription)"
         )
     }
 
@@ -305,7 +297,7 @@ public class CBChatRegistry: NSObject, IMDaemonListenerProtocol {
         chatProperties properties: [AnyHashable: Any]!,
         messagesUpdated messages: [NSObject]!
     ) {
-        trace(chatIdentifier, nil, "messages updated \((messages! as NSArray))")
+        trace(chatIdentifier, nil, "messages updated \((messages! as NSArray).singleLineDebugDescription)")
         messages.forEach {
             handle(chatIdentifier: chatIdentifier, properties: properties, groupID: nil, item: $0)
         }

--- a/Core/Barcelona/IMCoreHelpers/BarcelonaManager.swift
+++ b/Core/Barcelona/IMCoreHelpers/BarcelonaManager.swift
@@ -162,6 +162,11 @@ public func BLBootstrapController(
         } else {
             controller.loadChats(withChatID: "all")
         }
+
+        for account in IMAccountController.shared.accounts {
+            // We want to make sure that nothing is prohibited us
+            account.updateCapabilities(UInt64.max)
+        }
     }
 
     if BLIsSimulation {

--- a/Core/Barcelona/IMCoreHelpers/HookManager.swift
+++ b/Core/Barcelona/IMCoreHelpers/HookManager.swift
@@ -70,7 +70,7 @@ private func IMHandleHooks() throws -> Interpose {
     }
 }
 
-private func IMChatHooks() throws -> Interpose {
+/*private func IMChatHooks() throws -> Interpose {
     try Interpose(IMChat.self) {
         try $0.prepareHook(#selector(IMChat._handleIncomingItem(_:))) {
             (
@@ -142,7 +142,7 @@ private func IMChatHooks() throws -> Interpose {
             }
         }
     }
-}
+}*/
 
 private func IDSServiceHooks() throws -> Interpose {
     try Interpose(NSClassFromString("_IDSService")!) {
@@ -173,7 +173,7 @@ private func IMIDSHooks() throws -> Interpose {
 public class HookManager {
     public static let shared = HookManager()
 
-    let hooks = [IMChatHooks, IMIDSHooks, CNLogSilencerHooks, IMHandleHooks, IDSServiceHooks]
+    let hooks = [/*IMChatHooks, */IMIDSHooks, CNLogSilencerHooks, IMHandleHooks, IDSServiceHooks]
     private var appliedHooks: [Interpose]?
 
     public func apply() throws {

--- a/Core/Barcelona/IMCoreHelpers/Query.swift
+++ b/Core/Barcelona/IMCoreHelpers/Query.swift
@@ -1,0 +1,254 @@
+//
+//  Query.swift
+//  grapple
+//
+//  Created by Eric Rabil on 11/24/21.
+//
+
+import Foundation
+import SwiftCLI
+import IMCore
+
+public struct EncodingBox: Encodable {
+    public var ref: (Encoder) throws -> ()
+    
+    public init(encodable: Encodable) {
+        ref = encodable.encode(to:)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        try ref(encoder)
+    }
+}
+
+@_spi(EncodingBoxInternals) public var visited: Set<NSObject> = Set()
+
+// Look up a bunch of methods/impls on NSInvocation
+let nsInvocationClass: AnyClass = NSClassFromString("NSInvocation")!
+
+// Look up the "invocationWithMethodSignature:" method
+let nsInvocationInitializer = unsafeBitCast(
+    method_getImplementation(
+        class_getClassMethod(nsInvocationClass, NSSelectorFromString("invocationWithMethodSignature:"))!
+    ),
+    to: (@convention(c) (AnyClass?, Selector, Any?) -> Any).self
+)
+
+// Look up the "setSelector:" method
+let nsInvocationSetSelector = unsafeBitCast(
+    class_getMethodImplementation(nsInvocationClass, NSSelectorFromString("setSelector:")),
+    to:(@convention(c) (Any, Selector, Selector) -> Void).self
+)
+
+let nsInvocationSetTarget = unsafeBitCast(
+    class_getMethodImplementation(nsInvocationClass, NSSelectorFromString("setTarget:")),
+    to: (@convention(c) (NSObject, Selector, NSObject) -> Void).self
+)
+
+let nsInvocationRetainArguments = unsafeBitCast(
+    class_getMethodImplementation(nsInvocationClass, NSSelectorFromString("retainArguments")),
+    to: (@convention(c) (NSObject, Selector) -> Void).self
+)
+
+let nsInvocationInvoke = unsafeBitCast(
+    class_getMethodImplementation(nsInvocationClass, NSSelectorFromString("invoke")),
+    to: (@convention(c) (NSObject, Selector) -> Void).self
+)
+
+let nsInvocationGetReturnValue = unsafeBitCast(
+    class_getMethodImplementation(nsInvocationClass, NSSelectorFromString("getReturnValue:")),
+    to: (@convention(c) (NSObject, Selector, UnsafeMutableRawPointer) -> Void).self
+)
+
+let invokeWithTargetSelector = NSSelectorFromString("invokeWithTarget:")
+var result: UnsafeMutableRawPointer = .allocate(byteCount: 0, alignment: 0)
+
+#if os(iOS)
+public extension NSObject {
+    var className: String {
+        NSStringFromClass(Self.self)
+    }
+}
+#endif
+
+extension NSObject: Encodable {
+    var propertyBlacklist: [String] {
+        switch self {
+        case is IMAccount:
+            return ["accountImageData", "arrayOfAllIMHandles", "service"]
+        case is IMHandle:
+            return ["siblingsArray", "account", "siblings", "service"]
+        case is IMService:
+            return ["siblingServices"]
+        case is IMChat:
+            return ["autoDonateMessages", "chatRegistry"]
+        default:
+            return ["_isSymbolImage", "defaultSize", "_symbolImage", "bitmapData", "CGImage", "colorSyncProfile", "CGColorSpace", "_animated", "_mapkit_CLDenied", "_mapkit_CLLocationUnknown"]
+        }
+    }
+    
+    private var properties: [String] {
+        var count: UInt32 = 0
+        guard let propertyList = class_copyPropertyList(Self.self, &count) else {
+            return []
+        }
+        
+        defer { free(propertyList) }
+        
+        return UnsafeMutableBufferPointer(start: propertyList, count: Int(count)).map(property_getName(_:)).map(String.init(cString:)).filter { !propertyBlacklist.contains($0) }
+    }
+    
+    struct StringLiteralCodingKey: CodingKey, ExpressibleByStringLiteral {
+        var stringValue: String
+        var intValue: Int?
+        
+        init(stringValue: String) {
+            self.stringValue = stringValue
+        }
+        
+        init(stringLiteral: String) {
+            self.stringValue = stringLiteral
+        }
+        
+        init(intValue: Int) {
+            stringValue = intValue.description
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        if visited.contains(self) {
+            switch self {
+            case let array as NSArray:
+                if array.allSatisfy({ $0 is String || $0 is NSString || $0 is NSMutableString || $0 is NSNumber || ($0 as? NSObject)?.className == "CNLabeledValue" }) {
+                    break
+                }
+                var container = encoder.singleValueContainer()
+                try container.encode("<Circular reference to \(debugDescription)>")
+                return
+            case let dict as NSDictionary:
+                if dict.allValues.allSatisfy({ $0 is String || $0 is NSString || $0 is NSMutableString || $0 is NSNumber || ($0 as? NSObject)?.className == "CNLabeledValue" }) {
+                    break
+                }
+                var container = encoder.singleValueContainer()
+                try container.encode("<Circular reference to \(debugDescription)>")
+                return
+            case is NSDate, is NSString, is NSNumber, is NSValue:
+                break
+            default:
+                var container = encoder.singleValueContainer()
+                try container.encode("<Circular reference to \(debugDescription)>")
+                return
+            }
+        }
+        
+        switch self {
+        case is DispatchData:
+            var container = encoder.singleValueContainer()
+            try container.encode("DispatchData")
+            return
+        default:
+            break
+        }
+        
+        switch self {
+        case is NSString, is NSMutableString, is NSNumber:
+            break
+        default:
+            if className == "CNLabeledValue" {
+                break
+            }
+            
+            visited.insert(self)
+        }
+        
+        switch self {
+        case let number as NSNumber:
+            var container = encoder.singleValueContainer()
+            try container.encode(number.doubleValue)
+        case let string as NSString:
+            var container = encoder.singleValueContainer()
+            try container.encode(string as String)
+        case let string as NSMutableString:
+            var container = encoder.singleValueContainer()
+            try container.encode(string as String)
+        case let dictionary as NSDictionary:
+            var container = encoder.container(keyedBy: StringLiteralCodingKey.self)
+            
+            for key in dictionary.allKeys {
+                try container.encodeIfPresent((dictionary[key] as? Encodable).map(EncodingBox.init(encodable:)), forKey: .init(stringValue: String(describing: key)))
+            }
+        case let dictionary as NSMutableDictionary:
+            var container = encoder.container(keyedBy: StringLiteralCodingKey.self)
+            
+            for key in dictionary.allKeys {
+                try container.encodeIfPresent((dictionary[key] as? Encodable).map(EncodingBox.init(encodable:)), forKey: .init(stringValue: String(describing: key)))
+            }
+        case let array as NSArray:
+            var container = encoder.unkeyedContainer()
+            
+            for element in array {
+                if let encodable = element as? Encodable {
+                    try container.encode(EncodingBox(encodable: encodable))
+                } else {
+                    try container.encodeNil()
+                }
+            }
+        case let url as NSURL:
+            var container = encoder.singleValueContainer()
+            try container.encode(url.absoluteString)
+        case let date as NSDate:
+            var container = encoder.singleValueContainer()
+            try container.encode(date.debugDescription)
+        case let array as NSMutableArray:
+            var container = encoder.unkeyedContainer()
+            
+            for element in array {
+                if let encodable = element as? Encodable {
+                    try container.encode(EncodingBox(encodable: encodable))
+                } else {
+                    try container.encodeNil()
+                }
+            }
+        default:
+            var container = encoder.container(keyedBy: StringLiteralCodingKey.self)
+            
+            var result: Any?
+
+            let valueForKey = value(forKey:)
+            for key in properties {
+                do {
+                    try ObjC.catchException {
+                        result = valueForKey(key)
+                    }
+                } catch {
+                    try container.encodeNil(forKey: .init(stringValue: key))
+                    continue
+                }
+                
+                if let object = result as? NSObject, visited.contains(object) {
+                    switch object {
+                    case is NSDate, is NSString, is NSNumber, is NSValue:
+                        break
+                    case let array as NSArray:
+                        if array.allSatisfy({ $0 is String || $0 is NSString || $0 is NSMutableString || $0 is NSNumber || ($0 as? NSObject)?.className == "CNLabeledValue" }) {
+                            break
+                        }
+                        try container.encode("Circular reference to \(object.debugDescription)", forKey: .init(stringValue: key))
+                        continue
+                    case let dict as NSDictionary:
+                        if dict.allValues.allSatisfy({ $0 is String || $0 is NSString || $0 is NSMutableString || $0 is NSNumber || ($0 as? NSObject)?.className == "CNLabeledValue" }) {
+                            break
+                        }
+                        try container.encode("Circular reference to \(object.debugDescription)", forKey: .init(stringValue: key))
+                        continue
+                    default:
+                        try container.encode("Circular reference to \(object.debugDescription)", forKey: .init(stringValue: key))
+                        continue
+                    }
+                }
+                
+                try container.encodeIfPresent((result as? Encodable).map(EncodingBox.init(encodable:)), forKey: .init(stringValue: key))
+            }
+        }
+    }
+}

--- a/Core/Barcelona/IMCoreHelpers/Scratchbox.swift
+++ b/Core/Barcelona/IMCoreHelpers/Scratchbox.swift
@@ -19,5 +19,5 @@ import IDS
 #endif
 
 @_spi(scratchbox) public func _scratchboxMain() {
-
+    
 }

--- a/Tools/grapple/Commands/ChatCommands.swift
+++ b/Tools/grapple/Commands/ChatCommands.swift
@@ -20,16 +20,18 @@ class ChatCommands: CommandGroup {
         let name = "list"
 
         func execute() throws {
-            print("printing most recent 20 chats")
+            _Concurrency.Task {
+                print("printing most recent 20 chats")
 
-            var table = TextTable(columns: [.init(header: "ID"), .init(header: "Name")])
+                var table = TextTable(columns: [.init(header: "ID"), .init(header: "Name")])
 
-            for chat in Chat.allChats.prefix(20) {
-                table.addRow(values: [chat.id, chat.displayName ?? chat.participantNames.joined(separator: ", ")])
+                for chat in await Chat.allChats.prefix(20) {
+                    table.addRow(values: [chat.id, chat.displayName ?? chat.participantNames.joined(separator: ", ")])
+                }
+
+                print(table.render())
+                exit(0)
             }
-
-            print(table.render())
-            exit(0)
         }
     }
 
@@ -39,11 +41,11 @@ class ChatCommands: CommandGroup {
         @Param var id: String
 
         func execute() throws {
-            BLLoadChatItems(withChats: [.iMessage, .SMS].map { (id, $0) }, limit: 20)
-                .then {
-                    print($0)
-                    exit(0)
-                }
+            _Concurrency.Task {
+                let chats = try! await BLLoadChatItems(withChats: [.iMessage, .SMS].map { (id, $0) }, limit: 20)
+                print(chats)
+                exit(0)
+            }
         }
     }
 

--- a/Tools/grapple/Commands/DebugCommands.swift
+++ b/Tools/grapple/Commands/DebugCommands.swift
@@ -149,21 +149,16 @@ class DebugCommands: CommandGroup {
         let name = "imd"
 
         func execute() throws {
-
-            guard let _chat = IMChatRegistry.shared.allChats.first else {
-                return
-            }
-
-            typealias XYZ = @convention(c) (
-                UnsafeRawPointer, UnsafeRawPointer, UnsafeRawPointer, UnsafeRawPointer, UnsafeRawPointer
-            ) -> Void
-
-            let chat = Chat(_chat)
-
-            chat.messages()
-                .then {
-                    print($0)
+            _Concurrency.Task {
+                guard let _chat = IMChatRegistry.shared.allChats.first else {
+                    return
                 }
+
+                let chat = Chat(_chat)
+
+                let msgs = try await chat.messages()
+                print(msgs)
+            }
         }
     }
 

--- a/Tools/grapple/Commands/ListCommand.swift
+++ b/Tools/grapple/Commands/ListCommand.swift
@@ -44,7 +44,7 @@ class TransferCommands: CommandGroup {
             let name = "all"
 
             func execute() throws {
-                print(IMFileTransferCenter.sharedInstance().transfers.prettyJSON)
+                print(IMFileTransferCenter.sharedInstance().transfers.mapValues(\.debugDescription).prettyJSON)
             }
         }
 

--- a/Tools/grapple/Commands/Query.swift
+++ b/Tools/grapple/Commands/Query.swift
@@ -59,8 +59,6 @@ class QueryCommand: EphemeralBarcelonaCommand {
             case .chats:
                 send(IMChatRegistry.shared.allChats.collectedDictionary(keyedBy: \.chatIdentifier) as NSDictionary)
             }
-
-            visited = Set()
         }
     }
 

--- a/Tools/grapple/Commands/RegressionTesting.swift
+++ b/Tools/grapple/Commands/RegressionTesting.swift
@@ -46,11 +46,11 @@ class RegressionTestingCommand: CommandGroup {
 
         func execute() throws {
             if ids.isEmpty {
-                print(BarcelonaMautrixIPC.RegressionTesting.tests.keys.map { "- \($0)" }.joined(separator: "\n"))
+                print(BLRegressionTesting.tests.keys.map { "- \($0)" }.joined(separator: "\n"))
                 exit(0)
             }
             for id in ids {
-                guard let test = BarcelonaMautrixIPC.RegressionTesting.tests[id.uppercased()] else {
+                guard let test = BLRegressionTesting.tests[id.uppercased()] else {
                     print("skipping \(id): unknown test")
                     continue
                 }

--- a/Tools/grapple/Debugging/ReadReceiptTester.swift
+++ b/Tools/grapple/Debugging/ReadReceiptTester.swift
@@ -66,7 +66,12 @@ class ReadReceiptTester: GrappleDebugger {
         log.info("marking \(message.id) as read in \(self.config.delay)ms")
 
         DispatchQueue.main.asyncAfter(deadline: .now().advanced(by: .milliseconds(config.delay))) {
-            message.imChat.markMessage(asRead: BLLoadIMMessage(withGUID: message.id)!)
+            guard let imChat = message.imChat else {
+                self.log.warning("IMChat for \(message.chatID),\(message.service) can't be found")
+                return
+            }
+
+            imChat.markMessage(asRead: BLLoadIMMessage(withGUID: message.id)!)
         }
     }
 

--- a/Tools/grapple/TextTableRepresentable/IMAccount.swift
+++ b/Tools/grapple/TextTableRepresentable/IMAccount.swift
@@ -20,7 +20,7 @@ extension IMAccount: TextTableRepresentable {
 
     public var tableValues: [CustomStringConvertible] {
         [
-            service?.id.rawValue ?? "nil",
+            service?.id?.rawValue ?? "nil",
             uniqueID ?? "nil",
             login ?? "nil",
             loginIMHandle?.id ?? "nil",


### PR DESCRIPTION
- Add `com.apple.imdpersistence.IMDPersistenceAgent` to allowed mach lookups to potentially fix IMDPersistence xpc lookups not working (a part of https://linear.app/beeper/issue/BE-8073#comment-4b207c7d)
- Re-enable debug descriptions (they don't leak any private information like the content of the message; they only show metadata and are very important to tracking messages as they go through the system. We need them.)
- Remove some unused functions from the `CBSenderCorrelationController`
- Block some calls to `CBSenderCorrelationController` to prevent data races from `Pwomise`
- Add more `singleLineDebugDescription` calls to get cleaner logs
- Force `IMAccount` capabilities to the max values so that we aren't prevented from doing anything we want to do (lack of capabilities could currently be preventing calls to `startWatchingHandle:account:` from going through)
- Comment out a suspicious hook that prevents some potentially important notifications from firing (the hook seemed to fire off a notification that we don't listen to anymore, and then block any more notifications from being posted inside the function, some of which are definitely important for other parts of the system functioning correctly)
- Fix some compilation errors in grapple that were being annoying