### PR TITLE
Try to fix crash in ERTimeSortedParticipantsManager

### DIFF
--- a/Beeper/BarcelonaMautrixIPC/Commands/Protocols/ChatResolvable.swift
+++ b/Beeper/BarcelonaMautrixIPC/Commands/Protocols/ChatResolvable.swift
@@ -17,19 +17,21 @@ protocol ChatResolvable {
 extension ChatResolvable {
     @MainActor
     var chat: IMChat? {
-        if let chat = IMChatRegistry.shared.existingChat(withGUID: chat_guid) {
-            return chat
-        } else {
-            var parsed = ParsedGUID(rawValue: chat_guid)
-
-            let service = parsed.service == "iMessage" ? IMServiceStyle.iMessage : .SMS
-            let id = parsed.last
-
-            if id.isPhoneNumber || id.isEmail || id.isBusinessID {
-                return Chat.directMessage(withHandleID: id, service: service).imChat
+        get async {
+            if let chat = IMChatRegistry.shared.existingChat(withGUID: chat_guid) {
+                return chat
             } else {
-                parsed.service = service == .iMessage ? "SMS" : "iMessage"
-                return IMChatRegistry.shared.existingChat(withGUID: parsed.description)
+                var parsed = ParsedGUID(rawValue: chat_guid)
+
+                let service = parsed.service == "iMessage" ? IMServiceStyle.iMessage : .SMS
+                let id = parsed.last
+
+                if id.isPhoneNumber || id.isEmail || id.isBusinessID {
+                    return await Chat.directMessage(withHandleID: id, service: service).imChat
+                } else {
+                    parsed.service = service == .iMessage ? "SMS" : "iMessage"
+                    return IMChatRegistry.shared.existingChat(withGUID: parsed.description)
+                }
             }
         }
     }
@@ -38,17 +40,19 @@ extension ChatResolvable {
         ParsedGUID(rawValue: chat_guid).service == "iMessage" ? IMServiceStyle.iMessage : .SMS
     }
 
-    @MainActor
     var cbChat: Chat? {
-        guard let chat = chat else {
-            return nil
-        }
+        get async {
+            guard let chat = await chat else {
+                return nil
+            }
 
-        return Chat(chat)
+            return await Chat(chat)
+        }
     }
 
-    @MainActor
     var blChat: BLChat? {
-        chat?.blChat
+        get async {
+            await chat?.blChat
+        }
     }
 }

--- a/Core/Barcelona/Extensions/Glue/IMChat+TimeSortedParticipants.swift
+++ b/Core/Barcelona/Extensions/Glue/IMChat+TimeSortedParticipants.swift
@@ -25,16 +25,20 @@ extension Array where Element: Hashable {
 
 extension IMChat {
     fileprivate var cachedRecentParticipantHandleIDs: [String] {
-        ERTimeSortedParticipantsManager.sharedInstance.sortedParticipants(forChat: self.chatIdentifier)
-            .filter(self.participantHandleIDs().contains)
-            .removingDuplicates()
+        get async {
+            await ERTimeSortedParticipantsManager.sharedInstance.sortedParticipants(forChat: chatIdentifier)
+                .filter(participantHandleIDs().contains)
+                .removingDuplicates()
+        }
     }
 
     public var recentParticipantHandleIDs: [String] {
-        var cachedRecent = cachedRecentParticipantHandleIDs
+        get async {
+            var cachedRecent = await cachedRecentParticipantHandleIDs
 
-        cachedRecent.append(contentsOf: participantHandleIDs().filter { !cachedRecent.contains($0) })
+            cachedRecent.append(contentsOf: participantHandleIDs().filter { !cachedRecent.contains($0) })
 
-        return cachedRecent
+            return cachedRecent
+        }
     }
 }

--- a/Core/Barcelona/Extensions/Glue/Publishers.swift
+++ b/Core/Barcelona/Extensions/Glue/Publishers.swift
@@ -29,15 +29,11 @@ extension Publisher {
 }
 
 extension Sequence {
-    func asyncMap<T>(_ transform: @escaping (Element) async -> T) async -> [T] {
-        await withTaskGroup(of: T.self, returning: [T].self) { group in
-            for item in self {
-                group.addTask {
-                    await transform(item)
-                }
-            }
-
-            return await group.reduce(into: []) { $0.append($1) }
+    func asyncMap<T>(_ transform: (Element) async throws -> T) async rethrows -> [T] {
+        var values = [T]()
+        for element in self {
+            values.append(try await transform(element))
         }
+        return values
     }
 }

--- a/Core/Barcelona/Extensions/Identifiable/Searchable/Chat+Searchable.swift
+++ b/Core/Barcelona/Extensions/Identifiable/Searchable/Chat+Searchable.swift
@@ -236,18 +236,20 @@ extension Array where Element: Equatable {
 }
 
 extension Chat: Searchable {
-    public static func resolve(withParameters rawParameters: ChatSearchParameters) -> Promise<[Chat]> {
+    public static func resolve(withParameters rawParameters: ChatSearchParameters) async -> [Chat] {
         let parameters = rawParameters.parameters
 
         if parameters.count == 0 {
-            return .success([])
+            return []
         }
 
-        var chats = IMChatRegistry.shared.allChats
+        var chats = await IMChatRegistry.shared.allChats
             .filter {
                 parameters.test($0)
             }
-            .map(Chat.init(_:))
+            .asyncMap { imChat in
+                await Chat(imChat)
+            }
 
         chats.sort { chat1, chat2 in
             chat1.lastMessageTime > chat2.lastMessageTime
@@ -257,6 +259,6 @@ extension Chat: Searchable {
             chats = Array(chats.prefix(limit))
         }
 
-        return .success(chats)
+        return chats
     }
 }

--- a/Core/Barcelona/Extensions/People/IMChatRegistry+SortedRepresentations.swift
+++ b/Core/Barcelona/Extensions/People/IMChatRegistry+SortedRepresentations.swift
@@ -25,7 +25,7 @@ extension IMChatRegistry {
     /**
      Returns all chats sorted by their last update, with a limit if requested
      */
-    public func allSortedChats(limit: Int? = nil, after: String? = nil) -> [Chat] {
+    public func allSortedChats(limit: Int? = nil, after: String? = nil) async -> [Chat] {
         var chats = allChats.sorted { (chat1, chat2) in
             let time1 =
                 chat1.lastMessage?.time ?? NSDate.__im_dateWithNanosecondTimeInterval(
@@ -43,6 +43,8 @@ extension IMChatRegistry {
             chats = Array(chats.prefix(limit))
         }
 
-        return chats.map(Chat.init)
+        return await chats.asyncMap { imChat in
+            await Chat(imChat)
+        }
     }
 }

--- a/Core/Barcelona/IMCoreHelpers/RegressionTesting.swift
+++ b/Core/Barcelona/IMCoreHelpers/RegressionTesting.swift
@@ -138,8 +138,8 @@ extension BLRegressionTesting {
         guard chat.willSendSMS else {
             preconditionFailure("Expected chat to be SMS targeted initially")
         }
-        let wrapper = Chat(chat)
         Task {
+            let wrapper = await Chat(chat)
             try! await wrapper.send(message: .init(parts: [.init(type: .text, details: "asdf")]))
         }
     }
@@ -177,7 +177,7 @@ extension BLRegressionTesting {
                 } else {
                     IMChat.regressionTesting_disableServiceRefresh = true
                 }
-                let chat = Chat(imChat)
+                let chat = await Chat(imChat)
                 do {
                     let message = try await chat.send(
                         message: CreateMessage(parts: [.init(type: .text, details: "asdf")])

--- a/Core/Barcelona/Wrappers/Core/Message.swift
+++ b/Core/Barcelona/Wrappers/Core/Message.swift
@@ -544,7 +544,12 @@ public struct Message: ChatItemOwned, CustomDebugStringConvertible, Hashable {
     }
 
     public var chat: Chat? {
-        imChat.map(Chat.init(_:))
+        get async {
+            guard let imChat else {
+                return nil
+            }
+            return await Chat(imChat)
+        }
     }
 
     public var associableItemIDs: [String] {


### PR DESCRIPTION
It's unclear what the actual issue is, but accessing `chatToParticipantSortRules` is causing a lot of crashes. Although locks didn't help, I want to see if the issue persists when using concurrency.
