### PR TITLE
Convert `CBChatRegistry` to an `actor`

### DIFF
--- a/Core/Barcelona/CoreBarcelona/Paris/CBChatRegistry.swift
+++ b/Core/Barcelona/CoreBarcelona/Paris/CBChatRegistry.swift
@@ -17,18 +17,20 @@ import Logging
 private let IMCopyThreadNameForChat: (@convention(c) (String, String, IMChatStyle) -> Unmanaged<NSString>)? =
     CBWeakLink(against: .privateFramework(name: "IMFoundation"), .symbol("IMCopyThreadNameForChat"))
 
-class CBChatRegistry: NSObject, IMDaemonListenerProtocol {
+class CBChatRegistry {
     var chats: [CBChatIdentifier: CBChat] = [:]
     var allChats: [ObjectIdentifier: CBChat] = [:]
 
     var messageIDReverseLookup: [String: CBChatIdentifier] = [:]
     private var subscribers: Set<AnyCancellable> = Set()
 
+    private let listenerBridge = IMDaemonListenerBridge()
+
     private let log = Logger(label: "CBChatRegistry")
 
-    override init() {
-        super.init()
-        IMDaemonController.shared().listener.addHandler(self)
+    init() {
+        listenerBridge.registry = self
+        IMDaemonController.shared().listener.addHandler(listenerBridge)
     }
 
     func setupComplete(_ success: Bool, info: [AnyHashable: Any]!) {

--- a/Core/Barcelona/CoreBarcelona/Paris/CBChatRegistry.swift
+++ b/Core/Barcelona/CoreBarcelona/Paris/CBChatRegistry.swift
@@ -32,15 +32,16 @@ actor CBChatRegistry {
     private var loadedChatsCallbacks: [() -> Void] = []
     private var queryCallbacks: [String: [() -> Void]] = [:]
 
-    private let listenerBridge = IMDaemonListenerBridge()
+    private lazy var listenerBridge = IMDaemonListenerBridge(registry: self)
     private let log = Logger(label: "CBChatRegistry")
     private var cancellables = Set<AnyCancellable>()
 
     // MARK: - Initializers
 
     init() {
-        listenerBridge.registry = self
-        IMDaemonController.shared().listener.addHandler(listenerBridge)
+        Task {
+            await IMDaemonController.shared().listener.addHandler(listenerBridge)
+        }
     }
 
     // MARK: - IMDaemonListenerProtocol

--- a/Core/Barcelona/CoreBarcelona/Paris/CBChatRegistry.swift
+++ b/Core/Barcelona/CoreBarcelona/Paris/CBChatRegistry.swift
@@ -39,7 +39,7 @@ actor CBChatRegistry {
     // MARK: - Initializers
 
     init() {
-        Task {
+        Task { @MainActor in
             await IMDaemonController.shared().listener.addHandler(listenerBridge)
         }
     }

--- a/Core/Barcelona/CoreBarcelona/Paris/IMDaemonListenerBridge.swift
+++ b/Core/Barcelona/CoreBarcelona/Paris/IMDaemonListenerBridge.swift
@@ -1,0 +1,305 @@
+//
+//  IMDaemonListenerBridge.swift
+//  Barcelona
+//
+//  Created by Joonas Myhrberg on 26.2.2023.
+//
+
+import Foundation
+import IMCore
+import IMFoundation
+import IMSharedUtilities
+import Logging
+
+/// Bridges delegate methods form `IMDaemonListenerProtocol` to `CBChatRegistry`.
+class IMDaemonListenerBridge: NSObject, IMDaemonListenerProtocol {
+
+    // MARK: - Properties
+
+    weak var registry: CBChatRegistry?
+
+    private let log = Logger(label: "CBChatRegistry")
+
+    // MARK: - Methods
+
+    func setupComplete(_ success: Bool, info: [AnyHashable: Any]!) {
+        Task {
+            await registry?.setupComplete(success, info: info)
+        }
+    }
+
+    func chat(_ persistentIdentifier: String!, updated updateDictionary: [AnyHashable: Any]!) {
+        Task {
+            await registry?.chat(persistentIdentifier, updated: updateDictionary)
+        }
+    }
+
+    func chat(_ persistentIdentifier: String!, propertiesUpdated properties: [AnyHashable: Any]!) {
+        Task {
+            await registry?.chat(persistentIdentifier, propertiesUpdated: properties)
+        }
+    }
+
+    func chat(_ persistentIdentifier: String!, engramIDUpdated engramID: String!) {
+        Task {
+            await registry?.chat(persistentIdentifier, engramIDUpdated: engramID)
+        }
+    }
+
+    func chat(_ guid: String!, lastAddressedHandleUpdated lastAddressedHandle: String!) {
+        Task {
+            await registry?.chat(guid, lastAddressedHandleUpdated: lastAddressedHandle)
+        }
+    }
+
+    func chatLoaded(withChatIdentifier chatIdentifier: String!, chats chatDictionaries: [Any]!) {
+        Task {
+            await registry?.chatLoaded(withChatIdentifier: chatIdentifier, chats: chatDictionaries)
+        }
+    }
+
+    func lastMessage(forAllChats chatIDToLastMessageDictionary: [AnyHashable: Any]!) {
+        Task {
+            await registry?.lastMessage(forAllChats: chatIDToLastMessageDictionary)
+        }
+    }
+
+    func service(
+        _ serviceID: String!,
+        chat chatIdentifier: String!,
+        style chatStyle: IMChatStyle,
+        messagesUpdated messages: [[AnyHashable: Any]]!
+    ) {
+        Task {
+            await registry?.service(serviceID, chat: chatIdentifier, style: chatStyle, messagesUpdated: messages)
+        }
+    }
+
+    func account(
+        _ accountUniqueID: String!,
+        chat chatIdentifier: String!,
+        style chatStyle: IMChatStyle,
+        chatProperties properties: [AnyHashable: Any]!,
+        error: Error!
+    ) {
+        Task {
+            await registry?
+                .account(
+                    accountUniqueID,
+                    chat: chatIdentifier,
+                    style: chatStyle,
+                    chatProperties: properties,
+                    error: error
+                )
+        }
+    }
+
+    func account(
+        _ accountUniqueID: String!,
+        chat chatIdentifier: String!,
+        style chatStyle: IMChatStyle,
+        chatProperties properties: [AnyHashable: Any]!,
+        notifySentMessage msg: IMMessageItem!,
+        sendTime: NSNumber!
+    ) {
+        Task {
+            await registry?
+                .account(
+                    accountUniqueID,
+                    chat: chatIdentifier,
+                    style: chatStyle,
+                    chatProperties: properties,
+                    notifySentMessage: msg,
+                    sendTime: sendTime
+                )
+        }
+    }
+
+    func account(
+        _ accountUniqueID: String!,
+        chat chatIdentifier: String!,
+        style chatStyle: IMChatStyle,
+        chatProperties properties: [AnyHashable: Any]!,
+        groupID: String!,
+        chatPersonCentricID personCentricID: String!,
+        messagesReceived messages: [IMItem]!,
+        messagesComingFromStorage fromStorage: Bool
+    ) {
+        Task {
+            await registry?
+                .account(
+                    accountUniqueID,
+                    chat: chatIdentifier,
+                    style: chatStyle,
+                    chatProperties: properties,
+                    groupID: groupID,
+                    chatPersonCentricID: personCentricID,
+                    messagesReceived: messages,
+                    messagesComingFromStorage: fromStorage
+                )
+        }
+    }
+
+    func account(
+        _ accountUniqueID: String!,
+        chat chatIdentifier: String!,
+        style chatStyle: IMChatStyle,
+        chatProperties properties: [AnyHashable: Any]!,
+        groupID: String!,
+        chatPersonCentricID personCentricID: String!,
+        statusChanged status: FZChatStatus,
+        handleInfo: [Any]!
+    ) {
+        Task {
+            await registry?
+                .account(
+                    accountUniqueID,
+                    chat: chatIdentifier,
+                    style: chatStyle,
+                    chatProperties: properties,
+                    groupID: groupID,
+                    chatPersonCentricID: personCentricID,
+                    statusChanged: status,
+                    handleInfo: handleInfo
+                )
+        }
+    }
+
+    func account(
+        _ accountUniqueID: String!,
+        chat chatIdentifier: String!,
+        style chatStyle: IMChatStyle,
+        chatProperties properties: [AnyHashable: Any]!,
+        groupID: String!,
+        chatPersonCentricID personCentricID: String!,
+        messagesReceived messages: [IMItem]!
+    ) {
+        Task {
+            await registry?
+                .account(
+                    accountUniqueID,
+                    chat: chatIdentifier,
+                    style: chatStyle,
+                    chatProperties: properties,
+                    groupID: groupID,
+                    chatPersonCentricID: personCentricID,
+                    messagesReceived: messages
+                )
+        }
+    }
+
+    func account(
+        _ accountUniqueID: String!,
+        chat chatIdentifier: String!,
+        style chatStyle: IMChatStyle,
+        chatProperties properties: [AnyHashable: Any]!,
+        groupID: String!,
+        chatPersonCentricID personCentricID: String!,
+        messageReceived msg: IMItem!
+    ) {
+        Task {
+            await registry?
+                .account(
+                    accountUniqueID,
+                    chat: chatIdentifier,
+                    style: chatStyle,
+                    chatProperties: properties,
+                    groupID: groupID,
+                    chatPersonCentricID: personCentricID,
+                    messageReceived: msg
+                )
+        }
+    }
+
+    func account(
+        _ accountUniqueID: String!,
+        chat chatIdentifier: String!,
+        style chatStyle: IMChatStyle,
+        chatProperties properties: [AnyHashable: Any]!,
+        groupID: String!,
+        chatPersonCentricID personCentricID: String!,
+        messageSent msg: IMMessageItem!
+    ) {
+        Task {
+            await registry?
+                .account(
+                    accountUniqueID,
+                    chat: chatIdentifier,
+                    style: chatStyle,
+                    chatProperties: properties,
+                    groupID: groupID,
+                    chatPersonCentricID: personCentricID,
+                    messageSent: msg
+                )
+        }
+    }
+
+    func account(
+        _ accountUniqueID: String!,
+        chat chatIdentifier: String!,
+        style chatStyle: IMChatStyle,
+        chatProperties properties: [AnyHashable: Any]!,
+        updateProperties update: [AnyHashable: Any]!
+    ) {
+        Task {
+            await registry?
+                .account(
+                    accountUniqueID,
+                    chat: chatIdentifier,
+                    style: chatStyle,
+                    chatProperties: properties,
+                    updateProperties: update
+                )
+        }
+    }
+
+    func account(
+        _ accountUniqueID: String!,
+        chat chatIdentifier: String!,
+        style chatStyle: IMChatStyle,
+        chatProperties properties: [AnyHashable: Any]!,
+        messageUpdated msg: IMItem!
+    ) {
+        Task {
+            await registry?
+                .account(
+                    accountUniqueID,
+                    chat: chatIdentifier,
+                    style: chatStyle,
+                    chatProperties: properties,
+                    messageUpdated: msg
+                )
+        }
+    }
+
+    func account(
+        _ accountUniqueID: String!,
+        chat chatIdentifier: String!,
+        style chatStyle: IMChatStyle,
+        chatProperties properties: [AnyHashable: Any]!,
+        messagesUpdated messages: [NSObject]!
+    ) {
+        Task {
+            await registry?
+                .account(
+                    accountUniqueID,
+                    chat: chatIdentifier,
+                    style: chatStyle,
+                    chatProperties: properties,
+                    messagesUpdated: messages
+                )
+        }
+    }
+
+    func loadedChats(_ chats: [[AnyHashable: Any]]!, queryID: String!) {
+        Task {
+            await registry?.loadedChats(chats, queryID: queryID)
+        }
+    }
+
+    func loadedChats(_ chats: [[AnyHashable: Any]]!) {
+        Task {
+            await registry?.loadedChats(chats)
+        }
+    }
+}

--- a/Core/Barcelona/CoreBarcelona/Paris/IMDaemonListenerBridge.swift
+++ b/Core/Barcelona/CoreBarcelona/Paris/IMDaemonListenerBridge.swift
@@ -12,55 +12,59 @@ import IMSharedUtilities
 import Logging
 
 /// Bridges delegate methods form `IMDaemonListenerProtocol` to `CBChatRegistry`.
-class IMDaemonListenerBridge: NSObject, IMDaemonListenerProtocol {
+class IMDaemonListenerBridge: NSObject, IMDaemonListenerProtocol, @unchecked Sendable {
 
     // MARK: - Properties
 
-    weak var registry: CBChatRegistry?
+    private weak var registry: CBChatRegistry!
 
     private let log = Logger(label: "CBChatRegistry")
 
-    // MARK: - Methods
+    init(registry: CBChatRegistry) {
+        self.registry = registry
+    }
+
+    // MARK: - IMDaemonListenerProtocol
 
     func setupComplete(_ success: Bool, info: [AnyHashable: Any]!) {
         Task {
-            await registry?.setupComplete(success, info: info)
+            await registry.setupComplete(success, info: info)
         }
     }
 
     func chat(_ persistentIdentifier: String!, updated updateDictionary: [AnyHashable: Any]!) {
         Task {
-            await registry?.chat(persistentIdentifier, updated: updateDictionary)
+            await registry.chat(persistentIdentifier, updated: updateDictionary)
         }
     }
 
     func chat(_ persistentIdentifier: String!, propertiesUpdated properties: [AnyHashable: Any]!) {
         Task {
-            await registry?.chat(persistentIdentifier, propertiesUpdated: properties)
+            await registry.chat(persistentIdentifier, propertiesUpdated: properties)
         }
     }
 
     func chat(_ persistentIdentifier: String!, engramIDUpdated engramID: String!) {
         Task {
-            await registry?.chat(persistentIdentifier, engramIDUpdated: engramID)
+            await registry.chat(persistentIdentifier, engramIDUpdated: engramID)
         }
     }
 
     func chat(_ guid: String!, lastAddressedHandleUpdated lastAddressedHandle: String!) {
         Task {
-            await registry?.chat(guid, lastAddressedHandleUpdated: lastAddressedHandle)
+            await registry.chat(guid, lastAddressedHandleUpdated: lastAddressedHandle)
         }
     }
 
     func chatLoaded(withChatIdentifier chatIdentifier: String!, chats chatDictionaries: [Any]!) {
         Task {
-            await registry?.chatLoaded(withChatIdentifier: chatIdentifier, chats: chatDictionaries)
+            await registry.chatLoaded(withChatIdentifier: chatIdentifier, chats: chatDictionaries)
         }
     }
 
     func lastMessage(forAllChats chatIDToLastMessageDictionary: [AnyHashable: Any]!) {
         Task {
-            await registry?.lastMessage(forAllChats: chatIDToLastMessageDictionary)
+            await registry.lastMessage(forAllChats: chatIDToLastMessageDictionary)
         }
     }
 
@@ -71,7 +75,7 @@ class IMDaemonListenerBridge: NSObject, IMDaemonListenerProtocol {
         messagesUpdated messages: [[AnyHashable: Any]]!
     ) {
         Task {
-            await registry?.service(serviceID, chat: chatIdentifier, style: chatStyle, messagesUpdated: messages)
+            await registry.service(serviceID, chat: chatIdentifier, style: chatStyle, messagesUpdated: messages)
         }
     }
 
@@ -83,7 +87,7 @@ class IMDaemonListenerBridge: NSObject, IMDaemonListenerProtocol {
         error: Error!
     ) {
         Task {
-            await registry?
+            await registry
                 .account(
                     accountUniqueID,
                     chat: chatIdentifier,
@@ -103,7 +107,7 @@ class IMDaemonListenerBridge: NSObject, IMDaemonListenerProtocol {
         sendTime: NSNumber!
     ) {
         Task {
-            await registry?
+            await registry
                 .account(
                     accountUniqueID,
                     chat: chatIdentifier,
@@ -126,7 +130,7 @@ class IMDaemonListenerBridge: NSObject, IMDaemonListenerProtocol {
         messagesComingFromStorage fromStorage: Bool
     ) {
         Task {
-            await registry?
+            await registry
                 .account(
                     accountUniqueID,
                     chat: chatIdentifier,
@@ -151,7 +155,7 @@ class IMDaemonListenerBridge: NSObject, IMDaemonListenerProtocol {
         handleInfo: [Any]!
     ) {
         Task {
-            await registry?
+            await registry
                 .account(
                     accountUniqueID,
                     chat: chatIdentifier,
@@ -175,7 +179,7 @@ class IMDaemonListenerBridge: NSObject, IMDaemonListenerProtocol {
         messagesReceived messages: [IMItem]!
     ) {
         Task {
-            await registry?
+            await registry
                 .account(
                     accountUniqueID,
                     chat: chatIdentifier,
@@ -198,7 +202,7 @@ class IMDaemonListenerBridge: NSObject, IMDaemonListenerProtocol {
         messageReceived msg: IMItem!
     ) {
         Task {
-            await registry?
+            await registry
                 .account(
                     accountUniqueID,
                     chat: chatIdentifier,
@@ -221,7 +225,7 @@ class IMDaemonListenerBridge: NSObject, IMDaemonListenerProtocol {
         messageSent msg: IMMessageItem!
     ) {
         Task {
-            await registry?
+            await registry
                 .account(
                     accountUniqueID,
                     chat: chatIdentifier,
@@ -242,7 +246,7 @@ class IMDaemonListenerBridge: NSObject, IMDaemonListenerProtocol {
         updateProperties update: [AnyHashable: Any]!
     ) {
         Task {
-            await registry?
+            await registry
                 .account(
                     accountUniqueID,
                     chat: chatIdentifier,
@@ -261,7 +265,7 @@ class IMDaemonListenerBridge: NSObject, IMDaemonListenerProtocol {
         messageUpdated msg: IMItem!
     ) {
         Task {
-            await registry?
+            await registry
                 .account(
                     accountUniqueID,
                     chat: chatIdentifier,
@@ -280,7 +284,7 @@ class IMDaemonListenerBridge: NSObject, IMDaemonListenerProtocol {
         messagesUpdated messages: [NSObject]!
     ) {
         Task {
-            await registry?
+            await registry
                 .account(
                     accountUniqueID,
                     chat: chatIdentifier,
@@ -293,13 +297,13 @@ class IMDaemonListenerBridge: NSObject, IMDaemonListenerProtocol {
 
     func loadedChats(_ chats: [[AnyHashable: Any]]!, queryID: String!) {
         Task {
-            await registry?.loadedChats(chats, queryID: queryID)
+            await registry.loadedChats(chats, queryID: queryID)
         }
     }
 
     func loadedChats(_ chats: [[AnyHashable: Any]]!) {
         Task {
-            await registry?.loadedChats(chats)
+            await registry.loadedChats(chats)
         }
     }
 }

--- a/Core/Barcelona/IMCoreHelpers/BarcelonaManager.swift
+++ b/Core/Barcelona/IMCoreHelpers/BarcelonaManager.swift
@@ -94,7 +94,7 @@ func BLTeardown() {
 @_cdecl("BLBootstrapController")
 public func BLBootstrapController(
     _ callbackC: (@convention(c) (Bool) -> Void)? = nil,
-    _ callbackSwift: ((Bool) -> Void)? = nil
+    _ callbackSwift: (@Sendable (Bool) -> Void)? = nil
 ) -> Bool {
     guard BLSwizzleDaemonController() else {
         callbackC?(false)
@@ -175,11 +175,13 @@ public func BLBootstrapController(
         IMSimulatedDaemonController.beginSimulatingDaemon()
     }
 
-    CBChatRegistry.shared.onLoadedChats {
-        CBDaemonListener.shared.startListening()
-        callbackC?(true)
-        callbackSwift?(true)
-        log.info("All systems go!")
+    Task {
+        await CBChatRegistry.shared.onLoadedChats {
+            CBDaemonListener.shared.startListening()
+            callbackC?(true)
+            callbackSwift?(true)
+            log.info("All systems go!")
+        }
     }
 
     return true

--- a/Core/Barcelona/Wrappers/Core/Messaging/MessageSending.swift
+++ b/Core/Barcelona/Wrappers/Core/Messaging/MessageSending.swift
@@ -88,7 +88,12 @@ extension Chat {
     }
 
     private var cbChat: CBChat? {
-        imChat.flatMap { CBChatRegistry.shared.chats[.guid($0.guid)] }
+        get async {
+            guard let imChat else {
+                return nil
+            }
+            return await CBChatRegistry.shared.chats[.guid(imChat.guid)]
+        }
     }
 
     public func sendReturningRaw(message createMessage: CreateMessage, from: String? = nil) async throws -> IMMessage {
@@ -98,7 +103,7 @@ extension Chat {
 
         let log = Logger(label: "Chat")
 
-        if let cbChat = cbChat {
+        if let cbChat = await cbChat {
             // If we're targeting the SMS service and call imChat.refreshServiceForSending(), it'll probably retarget to iMessage,
             // which we distinctly don't want it to do. Plus, we're implementing this to solve BE-7179, which has only happened
             // over iMessage as far as we can tell, so we don't need to work with SMS


### PR DESCRIPTION
`CBChatRegistry` is crashing a lot, seemingly because of concurrent access to the `chats` property. Converting it to an `actor` should fix it or at least reveal possible other causes for the constant crashes.
