### PR TITLE
Hook _IDSIDQueryController.__sendMessage to get better logs

### DIFF
--- a/Beeper/barcelona-mautrix/BarcelonaMautrix.swift
+++ b/Beeper/barcelona-mautrix/BarcelonaMautrix.swift
@@ -121,47 +121,49 @@ class BarcelonaMautrix {
     }
 
     func run() {
-        bootstrap()
+        Task {
+            await bootstrap()
+        }
 
         RunLoop.main.run()
     }
 
-    func bootstrap() {
+    func bootstrap() async {
         let startupSpan = SentrySDK.span
         let bootstrapSpan = startupSpan?.startChild(operation: "bootstrap")
         log.info("Bootstrapping")
 
-        BarcelonaManager.shared.bootstrap(chatRegistry: chatRegistry)
-            .catch { error in
-                log.error("fatal error while setting up barcelona: \(String(describing: error))")
+        do {
+            let success = try await BarcelonaManager.shared.bootstrap(chatRegistry: chatRegistry)
+
+            guard success else {
+                log.error("Failed to bootstrap")
                 startupSpan?.finish(status: .internalError)
                 bootstrapSpan?.finish(status: .internalError)
-                exit(197)
+                exit(-1)
             }
-            .then { success in
-                guard success else {
-                    log.error("Failed to bootstrap")
-                    startupSpan?.finish(status: .internalError)
-                    bootstrapSpan?.finish(status: .internalError)
-                    exit(-1)
-                }
 
-                // allow payloads to start flowing
-                self.reader.ready = true
-                BLHealthTicker.shared.pinnedBridgeState = nil
+            // allow payloads to start flowing
+            self.reader.ready = true
+            BLHealthTicker.shared.pinnedBridgeState = nil
 
-                CBPurgedAttachmentController.shared.enabled = true
-                CBPurgedAttachmentController.shared.delegate = self.eventHandler
+            CBPurgedAttachmentController.shared.enabled = true
+            CBPurgedAttachmentController.shared.delegate = self.eventHandler
 
-                // starts the imessage notification processor
-                self.eventHandler.run()
+            // starts the imessage notification processor
+            self.eventHandler.run()
 
-                log.info("BLMautrix is ready")
+            log.info("BLMautrix is ready")
 
-                self.startHealthTicker()
-                bootstrapSpan?.finish()
-                startupSpan?.finish()
-            }
+            self.startHealthTicker()
+            bootstrapSpan?.finish()
+            startupSpan?.finish()
+        } catch {
+            log.error("fatal error while setting up barcelona: \(String(describing: error))")
+            startupSpan?.finish(status: .internalError)
+            bootstrapSpan?.finish(status: .internalError)
+            exit(197)
+        }
     }
 
     // starts the bridge state interval

--- a/Beeper/barcelona-mautrix/barcelona-mautrix.entitlements
+++ b/Beeper/barcelona-mautrix/barcelona-mautrix.entitlements
@@ -42,6 +42,8 @@
 		<string>com.apple.madrid</string>
 		<string>com.apple.private.alloy.biz</string>
 	</array>
+	<key>com.apple.private.ids.registration</key>
+	<true/>
 	<key>com.apple.private.imcore.imdpersistence.database-access</key>
 	<true/>
 	<key>com.apple.private.imcore.imremoteurlconnection</key>
@@ -89,6 +91,7 @@
 		<string>com.apple.imagent.desktop.Launched</string>
 		<string>com.apple.identityservicesd.desktop.auth</string>
 		<string>com.apple.identityservicesd.idquery.desktop.auth</string>
+		<string>com.apple.identityservicesd.idquery.embedded.auth</string>
 		<string>com.apple.logind</string>
 	</array>
 	<key>com.apple.security.temporary-exception.shared-preference.read-only</key>

--- a/Core/Barcelona/CoreBarcelona/Paris/CBChatRegistry.swift
+++ b/Core/Barcelona/CoreBarcelona/Paris/CBChatRegistry.swift
@@ -336,6 +336,7 @@ public actor CBChatRegistry {
 
     func loadedChats(_ chats: [[AnyHashable: Any]]!) async {
         log.info("loadedChats calling callbacks")
+        hasLoadedChats = true
         _ = await internalize(chats: chats)
         let loadedChatsCallbacks = loadedChatsCallbacks
         self.loadedChatsCallbacks = []

--- a/Core/Barcelona/IMCoreHelpers/HookManager.swift
+++ b/Core/Barcelona/IMCoreHelpers/HookManager.swift
@@ -7,8 +7,10 @@
 //
 
 import Foundation
+import IDS
 import IMCore
 import IMSharedUtilities
+import IMFoundation
 import InterposeKit
 import Logging
 
@@ -42,7 +44,7 @@ private let PNCopyBestGuessCountryCodeForNumber:
     )!
 
 private func IMHandleHooks() throws -> Interpose {
-    return try Interpose(IMHandle.self) {
+    try Interpose(IMHandle.self) {
         try $0.prepareHook(#selector(getter:IMHandle.countryCode)) {
             (
                 store: TypedHook<
@@ -74,10 +76,52 @@ private func IDSServiceHooks() throws -> Interpose {
     }
 }
 
+private func IDSQueryHooks() throws -> Interpose {
+    let log = Logger(label: "IDSQueryHook")
+
+    // Can't use the class itself since IDS.framework doesn't expose it to be linked against
+    return try Interpose(NSClassFromString("_IDSIDQueryController")!) {
+        try $0.prepareHook(#selector(_IDSIDQueryController.__sendMessage(_:queue:reply:failBlock:waitForReply:))) {
+            (
+                store: TypedHook<@convention (c) (
+                    AnyObject,
+                    Selector,
+                    OS_xpc_object,
+                    DispatchQueue,
+                    @escaping (OS_xpc_object?) -> Void,
+                    @escaping (NSError?) -> Void,
+                    Bool
+                ) -> Void,
+                @convention(block) (
+                    AnyObject, // _IDSIDQueryController; can't link against
+                    OS_xpc_object, // the message we're sending
+                    DispatchQueue, // the queue it's being sent on
+                    @escaping @convention(block) (OS_xpc_object?) -> Void, // The block that gets called when it succeeds the xpc call
+                    @escaping @convention(block) (NSError?) -> Void, // The block that gets called when it fails (not certain what 'failure' exactly is here)
+                    Bool // if we want the request to be synchronous
+                ) -> Void>
+            ) in
+            { controller, message, queue, replyBlock, failBlock, waitForReply  in
+                let logReplyBlock: (OS_xpc_object?) -> Void = { [replyBlock] replyObject in
+                    log.debug("Got reply for __sendMessage, is object: \(String(describing: replyObject))")
+                    replyBlock(replyObject)
+                }
+
+                let logFailureBlock: (NSError?) -> Void = { [failBlock] error in
+                    log.error("Got failure for __sendMessage, error is \(String(describing: error))")
+                    failBlock(error)
+                }
+
+                store.original(controller, store.selector, message, queue, logReplyBlock, logFailureBlock, waitForReply)
+            }
+        }
+    }
+}
+
 class HookManager {
     static let shared = HookManager()
 
-    let hooks = [CNLogSilencerHooks, IMHandleHooks, IDSServiceHooks]
+    let hooks = [CNLogSilencerHooks, IMHandleHooks, IDSServiceHooks, IDSQueryHooks]
     private var appliedHooks: [Interpose]?
 
     func apply() throws {


### PR DESCRIPTION
Something is happening in the XPC requests to identityservicesd to get information about IDS statuses, so this will hopefully provide us with better logging in that area. It also adds some more strings to entitlements files that are relevant to ids requests, but I don't expect them to fix anything; it's mostly just extra insurance, I guess?

This also rewrites the bootstrap functions to be async instead of using `Pwomise` (it was causing more issues with global async functions not catching in breakpoints); @myyra could you look it over and let me know if it looks like I messed anything up? I made sure to pull in your changes with passing around the `CBChatRegistry` so that shouldn't be an issue.