### PR TITLE
Allow for injecting custom IDS statuses with IDSResolver.queryMule

### DIFF
--- a/Beeper/BarcelonaMautrixIPC/IPCHandlers/BLEventHandler.swift
+++ b/Beeper/BarcelonaMautrixIPC/IPCHandlers/BLEventHandler.swift
@@ -53,7 +53,7 @@ public class BLEventHandler: CBPurgedAttachmentControllerDelegate {
 
 
     public func run() {
-		CBDaemonListener.shared.typingPipeline.sink(receiveValue: receiveTyping).store(in: &bag)
+        CBDaemonListener.shared.typingPipeline.sink(receiveValue: receiveTyping).store(in: &bag)
 
         CBDaemonListener.shared.messageStatusPipeline.sink { change in
             guard change.type == .read else {

--- a/Beeper/barcelona-mautrix/SendMessageCLICommand.swift
+++ b/Beeper/barcelona-mautrix/SendMessageCLICommand.swift
@@ -29,7 +29,9 @@ class SendMessageCLICommand: Command {
 
     @Param var chatGuid: String
     @Param var message: String?
-    @Param var overwriteAvailability: Bool?
+
+    @Flag("--force-available")
+    var overwriteAvailability: Bool
 
     private func sendMessage() async {
         let chat = await getIMChatForChatGuid(self.chatGuid)
@@ -39,7 +41,8 @@ class SendMessageCLICommand: Command {
             exit(1)
         }
 
-        if let overwriteAvailability {
+        if overwriteAvailability {
+            log.info("Forcing any IDS lookups to resolve to \"available\"")
             IDSResolver.overwrittenStatuses[chat.chatIdentifier] = overwriteAvailability ? 1 : 2
         }
 

--- a/Beeper/barcelona-mautrix/SendMessageCLICommand.swift
+++ b/Beeper/barcelona-mautrix/SendMessageCLICommand.swift
@@ -11,6 +11,7 @@ import Foundation
 import IMCore
 import Logging
 import SwiftCLI
+import BarcelonaMautrixIPC
 
 private let log = Logger(label: "SendMessageCLICommand")
 
@@ -28,6 +29,7 @@ class SendMessageCLICommand: Command {
 
     @Param var chatGuid: String
     @Param var message: String?
+    @Param var overwriteAvailability: Bool?
 
     private func sendMessage() async {
         let chat = await getIMChatForChatGuid(self.chatGuid)
@@ -37,15 +39,48 @@ class SendMessageCLICommand: Command {
             exit(1)
         }
 
+        if let overwriteAvailability {
+            IDSResolver.overwrittenStatuses[chat.chatIdentifier] = overwriteAvailability ? 1 : 2
+        }
+
         let messageCreation = CreateMessage(parts: [
             .init(type: .text, details: self.message ?? "Test Message")
         ])
 
         log.info("Message send task starting")
-        let _ = try! await chat.send(message: messageCreation)
+        let msg = try! await chat.send(message: messageCreation)
 
-        log.info("Message sent!")
-        exit(0)
+        log.info("Message sent: \(msg)\nAwaiting statuses...")
+
+        CBDaemonListener.shared.messageStatusPipeline.retainingSink { comp in
+            // I don't think we'll ever get a completion for this pipeline. if we do, just quit
+            log.info(":( messageStatusPipeline gave up on us: (\(comp))")
+            exit(1)
+        } receiveValue: { status in
+            guard status.messageID == msg.id else {
+                return
+            }
+
+            switch status.type {
+            case .sent:
+                log.info("Message was sent!")
+                if chat.account.service?.id != .iMessage || chat.isGroupChat {
+                    log.info("Message was sent to chat where there are no delivered statuses; exiting")
+                    exit(0)
+                }
+            case .delivered:
+                log.info("Message was delivered!! woohoo!!")
+                exit(0)
+            case .notDelivered:
+                log.info(":( Message was not delivered: \(status.message.errorCode)")
+                exit(0)
+            case .downgraded:
+                log.info("Uhhhh Message was downgraded somehow??: \(status.message.errorCode)")
+            default:
+                // don't care about anything else
+                break
+            }
+        }
     }
 
     func execute() throws {
@@ -56,32 +91,14 @@ class SendMessageCLICommand: Command {
         let controller = IMDaemonController.sharedInstance()
         controller.listener.addHandler(listener)
 
-        log.info("Connecting to daemon...")
-        controller.addListenerID("com.beeper.barcelona.send_message", capabilities: FZListenerCapabilities.defaults_)
-        controller.blockUntilConnected()
-        log.info("Connected to daemon.")
-
         // Set up a pipeline to send the message once we've finished loading
-        let readyPipeline = listener.readySubject.sink {
+        listener.readySubject.retainingSink { _ in } receiveValue: {
             log.info("Chats are loaded!")
             _Concurrency.Task {
                 await self.sendMessage()
             }
         }
 
-        log.info("Loading chats")
-        if #available(macOS 12, *) {
-            controller.loadAllChats()
-        } else {
-            controller.loadChats(withChatID: "all")
-        }
-
-        for account in IMAccountController.shared.accounts {
-            // We want to make sure that nothing is prohibited us
-            account.updateCapabilities(UInt64.max)
-        }
-
-        log.info("Starting the RunLoop")
-        RunLoop.main.run()
+        BarcelonaMautrix.run("/dev/null")
     }
 }

--- a/Core/Barcelona/CoreBarcelona/CBDaemonListener.swift
+++ b/Core/Barcelona/CoreBarcelona/CBDaemonListener.swift
@@ -268,7 +268,7 @@ public class CBDaemonListener: ERBaseDaemonListener {
 
     static var didStartListening = false
 
-    func startListening() async {
+    public func startListening() async {
         guard CBDaemonListener.didStartListening == false else {
             return
         }

--- a/Core/Barcelona/CoreBarcelona/CBDaemonListener.swift
+++ b/Core/Barcelona/CoreBarcelona/CBDaemonListener.swift
@@ -268,7 +268,7 @@ public class CBDaemonListener: ERBaseDaemonListener {
 
     static var didStartListening = false
 
-    func startListening() {
+    func startListening() async {
         guard CBDaemonListener.didStartListening == false else {
             return
         }
@@ -360,7 +360,7 @@ public class CBDaemonListener: ERBaseDaemonListener {
         }
 
         #if DEBUG
-        _scratchboxMain()
+        await _scratchboxMain()
         #endif
     }
 

--- a/Core/Barcelona/CoreBarcelona/Paris/CBChatRegistry.swift
+++ b/Core/Barcelona/CoreBarcelona/Paris/CBChatRegistry.swift
@@ -322,6 +322,8 @@ public actor CBChatRegistry {
     }
 
     func loadedChats(_ chats: [[AnyHashable: Any]]!) async {
+        if hasLoadedChats { return }
+
         log.info("loadedChats calling callbacks")
         hasLoadedChats = true
         _ = await internalize(chats: chats)

--- a/Core/Barcelona/CoreBarcelona/Paris/CBChatRegistry.swift
+++ b/Core/Barcelona/CoreBarcelona/Paris/CBChatRegistry.swift
@@ -30,7 +30,7 @@ public actor CBChatRegistry {
     private var messageIDReverseLookup: [String: CBChatIdentifier] = [:]
     private var loadedChatsByChatIdentifierCallback: [String: [([IMChat]) -> Void]] = [:]
     private var hasLoadedChats = false
-    private var loadedChatsCallbacks: [@Sendable () -> Void] = []
+    private var loadedChatsCallbacks: [@Sendable () async -> Void] = []
     private var queryCallbacks: [String: [() -> Void]] = [:]
 
     private lazy var listenerBridge = IMDaemonListenerBridge(registry: self)
@@ -329,16 +329,16 @@ public actor CBChatRegistry {
         self.loadedChatsCallbacks = []
         Task { @MainActor in
             for callback in loadedChatsCallbacks {
-                callback()
+                await callback()
             }
         }
     }
 
-    func onLoadedChats(_ callback: @Sendable @escaping () -> Void) {
+    func onLoadedChats(_ callback: @Sendable @escaping ()  async -> Void) {
         if hasLoadedChats {
             log.info("Already ready, let's go!")
             Task { @MainActor in
-                callback()
+                await callback()
             }
         } else {
             log.info("Not ready yet, waiting...")

--- a/Core/Barcelona/Extensions/Glue/Publishers.swift
+++ b/Core/Barcelona/Extensions/Glue/Publishers.swift
@@ -8,7 +8,7 @@
 import Combine
 import Foundation
 
-extension Publisher {
+public extension Publisher {
     @discardableResult
     func retainingSink(
         receiveCompletion: @escaping (Subscribers.Completion<Failure>) -> Void,

--- a/Core/Barcelona/Extensions/Glue/Publishers.swift
+++ b/Core/Barcelona/Extensions/Glue/Publishers.swift
@@ -8,6 +8,26 @@
 import Combine
 import Foundation
 
+extension Publisher {
+    @discardableResult
+    func retainingSink(
+        receiveCompletion: @escaping (Subscribers.Completion<Failure>) -> Void,
+        receiveValue: @escaping (Output) -> Void
+    ) -> AnyCancellable? {
+        var cancellable: AnyCancellable?
+        cancellable = sink(
+            receiveCompletion: {
+                receiveCompletion($0)
+
+                withExtendedLifetime(cancellable) { cancellable = nil }
+            },
+            receiveValue: receiveValue
+        )
+
+        return cancellable
+    }
+}
+
 extension Sequence {
     func asyncMap<T>(_ transform: (Element) async throws -> T) async rethrows -> [T] {
         var values = [T]()

--- a/Core/Barcelona/IDS.swift
+++ b/Core/Barcelona/IDS.swift
@@ -19,7 +19,7 @@ enum IDSResolverError: Error {
     case statusNotFound
 }
 
-class IDSResolver {
+public class IDSResolver {
 
     // MARK: - Properties
 
@@ -28,6 +28,11 @@ class IDSResolver {
     private static let log = Logger(label: "IDSResolver")
     private static let handleQueue = DispatchQueue.init(label: "HandleIDS")
     private static let idsListenerID = "SOIDSListener-com.apple.imessage-rest"
+
+    // Used for SendMessageCLICommand; allows you to overwrite specific ids
+    // so that when you request for their statuses, it always says that they're
+    // available through IDS (or not available, whatever you want)
+    public static var overwrittenStatuses = [String: Int64]()
 
     // MARK: - Methods
 
@@ -75,7 +80,15 @@ class IDSResolver {
     ///  - Returns: Dictionary mapping the destinations to the Int64 value of their state (as is returned by IDSIDQueryController)
     static func queryMule(for ids: [String]) async throws -> [String: Int64] {
         // hehe everything's available
-        ids.reduce(into: [:]) { $0[$1] = 1 }
+        ids.reduce(into: [:]) { dict, id in
+            // If any of the overwritten IDs are this id (or this id contains one of them,
+            // such as how "tel:+12345678900" contains "+12345678900"), then it's available
+            let overwrittenStatus = Self.overwrittenStatuses.first {
+                id.contains($0.key)
+            }?.value
+
+            dict[id] = overwrittenStatus ?? 0
+        }
     }
 
     /// Query IDS with or without cached results.

--- a/Core/Barcelona/IDS.swift
+++ b/Core/Barcelona/IDS.swift
@@ -69,6 +69,15 @@ class IDSResolver {
         }
     }
 
+    /// Queries echobot (or whatever other mule we're using) for the actual status of the given identifiers
+    ///  - Parameters:
+    ///    - ids: the identifiers to query, containing their `mailto:` or `tel:` prefixes
+    ///  - Returns: Dictionary mapping the destinations to the Int64 value of their state (as is returned by IDSIDQueryController)
+    static func queryMule(for ids: [String]) async throws -> [String: Int64] {
+        // hehe everything's available
+        ids.reduce(into: [:]) { $0[$1] = 1 }
+    }
+
     /// Query IDS with or without cached results.
     /// - Parameters:
     ///   - destinations: Destination handles.

--- a/Core/Barcelona/IMCoreHelpers/BarcelonaManager.swift
+++ b/Core/Barcelona/IMCoreHelpers/BarcelonaManager.swift
@@ -127,7 +127,7 @@ func BLBootstrapController(chatRegistry: CBChatRegistry) async -> Bool {
 
     log.info("Adding callback for CBChatRegistry to load chats")
     await chatRegistry.onLoadedChats {
-        CBDaemonListener.shared.startListening()
+        await CBDaemonListener.shared.startListening()
         log.info("All systems go!")
     }
 

--- a/Core/Barcelona/IMCoreHelpers/HookManager.swift
+++ b/Core/Barcelona/IMCoreHelpers/HookManager.swift
@@ -103,37 +103,90 @@ private func IDSQueryHooks() throws -> Interpose {
                 ) -> Void>
             ) in
             { controller, message, queue, replyBlock, failBlock, waitForReply  in
-                let logReplyBlock: (OS_xpc_object) -> Void = { [replyBlock] replyObject in
-
-                    if let swiftDict = replyObject.toSwiftDictionary() {
-                        // If we can turn it into a parseable dictionary, then print that instead of just the object
-                        log.debug("Got reply for __sendMessage, is dict: \(swiftDict.singleLineDebugDescription)")
-
-                        // I'm not certain some of these IDS types are available in lower than ventura, so we're not taking chances
-                        if #available(macOS 13.0, *),
-                           // Get the destinations
-                           let dest = swiftDict["destinations"] as? Data,
-                           // Unarchive it to a more understandable format
-                           let obj = try? NSKeyedUnarchiver.unarchivedObject(ofClasses: [
-                                NSDictionary.classForKeyedUnarchiver(),
-                                NSString.classForKeyedUnarchiver(),
-                                NSUUID.classForKeyedUnarchiver(),
-                                IDSIDInfoResult.classForKeyedUnarchiver(),
-                                IDSIDKTData.classForKeyedUnarchiver()
-                           ], from: dest) as? [String: IDSIDInfoResult]
-                        {
-                            log.debug("__sendMessage was invoked for an ids query, result is: \(obj.mapValues { $0.status() }.singleLineDebugDescription)")
-                        }
-                    } else {
-                        log.debug("Got reply for __sendMessage, is object: \(String(describing: replyObject))")
-                    }
-
-                    replyBlock(replyObject)
-                }
-
                 let logFailureBlock: (NSError?) -> Void = { [failBlock] error in
                     log.error("Got failure for __sendMessage, error is \(String(describing: error))")
                     failBlock(error)
+                }
+
+                let logReplyBlock: (OS_xpc_object) -> Void = { [replyBlock] replyObject in
+                    Task {
+                        if let swiftDict = replyObject.toSwiftDictionary() {
+                            // If we can turn it into a parseable dictionary, then print that instead of just the object
+                            log.debug("Got reply for __sendMessage, is dict: \(swiftDict.singleLineDebugDescription)")
+
+                            // I'm not certain some of these IDS types are available in lower than ventura, so we're not taking chances
+                            if #available(macOS 13.0, *), let dest = swiftDict["destinations"] as? Data {
+
+                                let reinsertData: ([String: Int64], ([String: Int64]) throws -> Data) async -> Void = { statuses, getData in
+                                    // If all the statuses say that they're available, then we don't need to ask anybody else about statuses
+                                    if statuses.values.allSatisfy({ $0 == 1 }) {
+                                        return
+                                    }
+
+                                    // Query echobot or whatever for the correct statuses
+                                    let realValues: [String: Int64]
+                                    do {
+                                        realValues = try await IDSResolver.queryMule(for: Array(statuses.keys))
+                                    } catch {
+                                        log.error("Couldn't query mule for real statuses of \(statuses.keys): \(error)")
+                                        return
+                                    }
+
+                                    do {
+                                        let dataVal = try getData(realValues)
+
+                                        // and if we got a good value, insert them
+                                        dataVal.withUnsafeBytes {
+                                            guard let dataPtr = $0.baseAddress else {
+                                                log.warning("Couldn't get baseAddress for data pointer to re-processed data")
+                                                return
+                                            }
+                                            xpc_dictionary_set_data(replyObject, "destinations", dataPtr, dataVal.count)
+                                        }
+                                    } catch {
+                                        log.warning("Couldn't convert new statuses to data in __sendMessage: \(error)")
+                                    }
+                                }
+
+                                // Unarchive it to a more understandable format
+                                if let obj = (try? NSKeyedUnarchiver.unarchivedObject(ofClasses: [
+                                    NSDictionary.classForKeyedUnarchiver(),
+                                    NSString.classForKeyedUnarchiver(),
+                                    NSUUID.classForKeyedUnarchiver(),
+                                    IDSIDInfoResult.classForKeyedUnarchiver(),
+                                    IDSIDKTData.classForKeyedUnarchiver()
+                                ], from: dest) as? [String: IDSIDInfoResult]) {
+                                    log.debug("__sendMessage was invoked for an ids query, returned archive is: \(obj.mapValues{ $0.status() }.singleLineDebugDescription)")
+
+                                    await reinsertData(obj.mapValues { $0.status() }) { realValues in
+                                        let results: [String: IDSIDInfoResult] = realValues.map {
+                                            IDSIDInfoResult(uri: $0, status: $1, endpoints: nil, ktData: nil, gameCenterData: nil)
+                                        }.reduce(into: [:], { $0[$1.uri()] = $1 })
+
+                                        return try NSKeyedArchiver.archivedData(withRootObject: results, requiringSecureCoding: false)
+                                    }
+                                } else if let obj = try? PropertyListSerialization.propertyList(from: dest, format: nil) as? any CustomDebugStringConvertible {
+                                    log.debug("__sendMessage was invoked for an ids query, returned plist is: \(obj.singleLineDebugDescription)")
+
+                                    // It should be in this format, but we just want to make sure
+                                    if let obj = obj as? [String: [String: Int64]], let stat = obj["com.apple.madrid"] {
+                                        await reinsertData(stat) { realValues in
+                                            return try PropertyListSerialization.data(fromPropertyList: ["com.apple.madrid": realValues.mapValues { $0 as NSNumber }], format: .binary, options: 0)
+                                        }
+                                    } else {
+                                        log.warning("__sendMessage obj was a plist, but not a dictionary; can't continue querying mule")
+                                    }
+                                } else {
+                                    // If we don't know what format it's in, just log and exit :(
+                                    log.warning("__sendMessage return value was not a known decodable format: \(dest)")
+                                }
+                            }
+                        } else {
+                            log.debug("Got reply for __sendMessage, is object: \(String(describing: replyObject))")
+                        }
+
+                        replyBlock(replyObject)
+                    }
                 }
 
                 store.original(controller, store.selector, message, queue, logReplyBlock, logFailureBlock, waitForReply)

--- a/Core/Barcelona/IMCoreHelpers/Scratchbox.swift
+++ b/Core/Barcelona/IMCoreHelpers/Scratchbox.swift
@@ -18,6 +18,6 @@ import IMFoundation
 import IDS
 #endif
 
-func _scratchboxMain() {
-
+func _scratchboxMain() async {
+    let res = try! await IDSResolver.resolveStatus(for: "10293847474388383", on: .iMessage)
 }

--- a/Core/Barcelona/IMCoreHelpers/Scratchbox.swift
+++ b/Core/Barcelona/IMCoreHelpers/Scratchbox.swift
@@ -19,5 +19,5 @@ import IDS
 #endif
 
 func _scratchboxMain() async {
-    let res = try! await IDSResolver.resolveStatus(for: "10293847474388383", on: .iMessage)
+
 }

--- a/XCSpec/spm.yaml
+++ b/XCSpec/spm.yaml
@@ -34,7 +34,7 @@ packages:
     exactVersion: 8.2.0
   Paris:
     url: https://github.com/beeper/Paris
-    revision: "850f6c0acc5597bdaa3414380fec2ea264bb95c2"
+    revision: "bd04987ca22ac12d68f4ad2194ae27c80a578589"
   SwiftNIO:
     url: https://github.com/apple/swift-nio
     from: 2.0.0


### PR DESCRIPTION
~~This doesn't allow for forcing an 'available' status with a cli flag, I'll implement that next.~~ Just added that; I think the CLI library we use is kinda messed up, but more on that later.

I've verified that this works when IDS returns a plist for the destinations, but sometimes it returns an `NSKeyed(Una|A)rchiver` thing (I think it did that on earlier versions of ventura? It used to do that on my computer, but doesn't anymore. I don't know what changed, honestly), and I can't guarantee this works for that. I may have to install an extra partition and play around with what version of ventura it's on to make it work.

Also this makes `scratchBox` async and adds the extra glue necessary for that. 

The function that you'll want to implement the 'querying echobot' functionality in is `IDSResolver.queryMule`. ~~right now it returns 'available' for every status, so we won't want to roll out this change until we've also implemented the echobot stuff.~~ Now it just checks to see if we've manually overwritten any statuses, e.g. with the cli commands, and uses those, otherwise returns unavailable for everything.

The code's kinda ugly and could probably be made simpler by making a func like `func hijackIDSResponse(in dict: inout OS_xpc_object)` (especially since that would allow for early exit instead of a bunch of nested `if { } else { }` statements... now that I'm thinking about it, I probably should do that), but I'll get around to that. Maybe when I add the send-message cli flag.

Ok, now re: the CLI library being messed up: I can't get the `overwriteAvailability` flag (to tell the send_message cmd to report a specific availability) to work nicely. E.g. if I do `barcelona-mautrix send_message iMessage;-;+12345678900 "example message" true`, it says that I've passed in a non-bool value for `overwriteAvailability`, but if I switch the order of the last two arguments, it gives the same error. Then, if I completely get rid of the `example message` argument, it thinks that I haven't passed in any value for `overwriteAvailability` and thinks that the message I want to send is "true". The only way I've found to trigger it correctly is to call `barcelona-mautrix send_message iMessage;-;+12345678900 true true`. this way, your text message will be `true`, but it will correctly process that you've passed in a value for `overwriteAvailability` and will get its value correctly. @bradtgmurray since I think you'll be using this the most, if you could try it out once merged and let me know if I'm crazy, that would be nice.

@myyra just like a cursory review would be great, make sure there's no weird code smells since I wrote most of this while tired.