### PR TITLE
Add retry to attachment uploads

### DIFF
--- a/Beeper/BarcelonaMautrixIPC/IPCHandlers/CommandHandlers/SendMediaMessageCommand+Handler.swift
+++ b/Beeper/BarcelonaMautrixIPC/IPCHandlers/CommandHandlers/SendMediaMessageCommand+Handler.swift
@@ -68,6 +68,9 @@ extension SendMediaMessageCommand: Runnable, AuthenticatedAsserting {
             )
         }
 
+        let canSend = imChat.canSendTransfer(imChat)
+        log.debug("Can send transfer to chat \(String(describing: imChat.guid)): \(canSend)")
+
         do {
             log.debug("Starting attachment upload")
             let guid = try await uploadAndRetry(filename: file_name, path: path_on_disk)

--- a/Core/Barcelona/CoreBarcelona/CBPurgedAttachmentController.swift
+++ b/Core/Barcelona/CoreBarcelona/CBPurgedAttachmentController.swift
@@ -149,7 +149,7 @@ class CBFileTransferCenter {
     }
 
     private func transferCreated(_ notification: Notification) {
-        guard let transfer = notification.decodeObject(to: IMFileTransfer.self) else {
+        guard let transfer = notification.decodeObject(to: IMFileTransfer.self), transfer.isIncoming else {
             return
         }
         guard let guid = transfer.guid else {
@@ -161,7 +161,7 @@ class CBFileTransferCenter {
     }
 
     private func transferUpdated(_ notification: Notification) {
-        guard let transfer = notification.decodeObject(to: IMFileTransfer.self) else {
+        guard let transfer = notification.decodeObject(to: IMFileTransfer.self), transfer.isIncoming else {
             return
         }
         guard let guid = transfer.guid else {
@@ -256,6 +256,9 @@ public class CBPurgedAttachmentController {
         let (transfers, supplemented) =
             transferIDs
             .compactMap(IMFileTransferCenter.sharedInstance().transfer(forGUID:))
+            .filter {
+                $0.isIncoming
+            }
             .filter { transfer in
                 transfer.needsUnpurging || !transfer.isTrulyFinished
             }

--- a/Core/Barcelona/Extensions/Glue/Publishers.swift
+++ b/Core/Barcelona/Extensions/Glue/Publishers.swift
@@ -8,9 +8,9 @@
 import Combine
 import Foundation
 
-public extension Publisher {
+extension Publisher {
     @discardableResult
-    func retainingSink(
+    public func retainingSink(
         receiveCompletion: @escaping (Subscribers.Completion<Failure>) -> Void,
         receiveValue: @escaping (Output) -> Void
     ) -> AnyCancellable? {
@@ -25,6 +25,43 @@ public extension Publisher {
         )
 
         return cancellable
+    }
+}
+
+// Copied from // https://github.com/JohnSundell/AsyncCompatibilityKit  as it doesn't have macOS support.
+@available(
+    macOS,
+    deprecated: 12.0,
+    message: "AsyncCompatibilityKit is only useful when targeting macOS versions earlier than 12"
+)
+extension Publisher {
+    /// Convert this publisher into an `AsyncThrowingStream` that
+    /// can be iterated over asynchronously using `for try await`.
+    /// The stream will yield each output value produced by the
+    /// publisher and will finish once the publisher completes.
+    public var values: AsyncThrowingStream<Output, Error> {
+        AsyncThrowingStream { continuation in
+            var cancellable: AnyCancellable?
+            let onTermination = { cancellable?.cancel() }
+
+            continuation.onTermination = { @Sendable _ in
+                onTermination()
+            }
+
+            cancellable = sink(
+                receiveCompletion: { completion in
+                    switch completion {
+                    case .finished:
+                        continuation.finish()
+                    case .failure(let error):
+                        continuation.finish(throwing: error)
+                    }
+                },
+                receiveValue: { value in
+                    continuation.yield(value)
+                }
+            )
+        }
     }
 }
 

--- a/Core/Barcelona/MediaUploader.swift
+++ b/Core/Barcelona/MediaUploader.swift
@@ -83,7 +83,7 @@ public class MediaUploader {
                 )
                 throw MediaUploadError.transferFailed(
                     code: transfer.error,
-                    description: transfer.errorDescription,
+                    description: transfer.errorDescription ?? "unknown error",
                     isRecoverable: false
                 )
             case .recoverableError:
@@ -92,7 +92,7 @@ public class MediaUploader {
                 )
                 throw MediaUploadError.transferFailed(
                     code: transfer.error,
-                    description: transfer.errorDescription,
+                    description: transfer.errorDescription ?? "unknown error",
                     isRecoverable: true
                 )
             default:

--- a/Core/Barcelona/MediaUploader.swift
+++ b/Core/Barcelona/MediaUploader.swift
@@ -1,0 +1,140 @@
+//
+//  MediaUploader.swift
+//  Barcelona
+//
+//  Created by Joonas Myhrberg on 20.4.2023.
+//
+
+import Foundation
+import IMCore
+import IMSharedUtilities
+import Logging
+
+public enum MediaUploadError: CustomNSError, LocalizedError {
+    /// Starting the transfer with `IMFileTransferCenter` failed.
+    case transferCreationFailed
+    /// Observing the status of an `IMFileTransfer` using notifications failed.
+    case tranferObservationFailed
+    /// The underlying `IMFileTransfer` had an error.
+    case transferFailed(code: Int64, description: String, isRecoverable: Bool)
+
+    var error: String {
+        switch self {
+        case .transferCreationFailed:
+            return "transferCreationFailed"
+        case .tranferObservationFailed:
+            return "tranferObservationFailed"
+        case .transferFailed(code: _, let description, let isRecoverable):
+            return "transferFailed: \(description), recoverable: \(isRecoverable)"
+        }
+    }
+
+    public var errorUserInfo: [String: Any] {
+        [NSDebugDescriptionErrorKey: error]
+    }
+
+    public var errorDescription: String? {
+        switch self {
+        case .transferCreationFailed:
+            return "Failed to start the attachment upload"
+        case .tranferObservationFailed:
+            return "Failed to get the status of the attachment upload"
+        case .transferFailed(code: _, let description, isRecoverable: _):
+            return "Failed to upload the attachment: \(description)"
+        }
+    }
+}
+
+public class MediaUploader {
+
+    private let log = Logger(label: "MediaUploader")
+
+    public init() {}
+
+    public func uploadFile(filename: String, path: URL) async throws -> String {
+        let transfer = try await createFileTransfer(for: filename, path: path)
+        guard let transferGUID = transfer.guid else {
+            throw MediaUploadError.transferCreationFailed
+        }
+
+        let updated = NotificationCenter.default.publisher(for: .IMFileTransferUpdated)
+        let finished = NotificationCenter.default.publisher(for: .IMFileTransferFinished)
+        let transferEvents = updated.merge(with: finished)
+            .throttle(for: 0.1, scheduler: DispatchQueue.main, latest: true)
+
+        for try await notification in transferEvents.values {
+            guard let transfer = notification.object as? IMFileTransfer else {
+                throw MediaUploadError.tranferObservationFailed
+            }
+
+            guard let guid = transfer.guid, guid == transferGUID else {
+                continue
+            }
+
+            log.info("Got transfer event notification for: \(guid) with state: \(transfer.state)")
+
+            switch transfer.state {
+            case .finished:
+                log.debug("Transfer \(guid) isFinished: \(transfer.isFinished)")
+                return guid
+            case .error:
+                log.error(
+                    "Transfer \(guid) has an error: \(transfer.error) with description: \(String(describing: transfer.errorDescription))"
+                )
+                throw MediaUploadError.transferFailed(
+                    code: transfer.error,
+                    description: transfer.errorDescription,
+                    isRecoverable: false
+                )
+            case .recoverableError:
+                log.error(
+                    "Transfer \(guid) has an recoverable error: \(transfer.error) with description: \(String(describing: transfer.errorDescription))"
+                )
+                throw MediaUploadError.transferFailed(
+                    code: transfer.error,
+                    description: transfer.errorDescription,
+                    isRecoverable: true
+                )
+            default:
+                continue
+            }
+        }
+
+        throw MediaUploadError.tranferObservationFailed
+    }
+
+    @MainActor
+    private func createFileTransfer(for filename: String, path: URL) throws -> IMFileTransfer {
+        let transferCenter = IMFileTransferCenter.sharedInstance()
+
+        let guid = transferCenter.guidForNewOutgoingTransfer(withLocalURL: path, useLegacyGuid: true)
+        guard let transfer = transferCenter.transfer(forGUID: guid) else {
+            throw MediaUploadError.transferCreationFailed
+        }
+
+        if let persistentPath = IMAttachmentPersistentPath(guid, filename, transfer.mimeType, transfer.type) {
+            let persistentURL = URL(fileURLWithPath: persistentPath)
+
+            try FileManager.default.createDirectory(
+                at: persistentURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+            try FileManager.default.copyItem(at: path, to: persistentURL)
+            transferCenter.cbRetargetTransfer(transfer, toPath: persistentPath)
+            transfer.localURL = persistentURL
+            log.info(
+                "Retargeted file transfer \(guid ?? "nil") from \(path) to \(persistentURL)",
+                source: "CBFileTransfer"
+            )
+        } else {
+            log.debug("No persistent path for transfer: \(String(describing: guid))")
+        }
+
+        transfer.transferredFilename = filename
+        transferCenter.registerTransfer(withDaemon: guid)
+        transferCenter.acceptTransfer(transfer.guid!)
+
+        return transfer
+    }
+}


### PR DESCRIPTION
Retry attachment uploads max 3 times before failing.

The `MediaUploader` class needs additional refactoring shortly, the structure ended up being quite stupid. I will probably merge it with the unpurging when that's refactored.